### PR TITLE
Sk add sql query backend route total users

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -17,7 +17,7 @@ export default function CommonsTable({ commons, currentUser }) {
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/commons/all"]
+        ["/api/commons/allplus"]
     );
     // Stryker enable all
 
@@ -31,43 +31,47 @@ export default function CommonsTable({ commons, currentUser }) {
     const columns = [
         {
             Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
+            accessor: 'commons.id', // accessor is the "key" in the data
 
         },
         {
             Header:'Name',
-            accessor: 'name',
+            accessor: 'commons.name',
         },
         {
             Header:'Cow Price',
-            accessor: row => String(row.cowPrice),
+            accessor: row => String(row.commons.cowPrice),
             id: 'cowPrice'
         },
         {
             Header:'Milk Price',
-            accessor: row => String(row.milkPrice),
+            accessor: row => String(row.commons.milkPrice),
             id: 'milkPrice'
         },
         {
             Header:'Starting Balance',
-            accessor: row => String(row.startingBalance),
+            accessor: row => String(row.commons.startingBalance),
             id: 'startingBalance'
         },
         {
             Header:'Starting Date',
-            accessor: row => String(row.startingDate).slice(0,10),
+            accessor: row => String(row.commons.startingDate).slice(0,10),
             id: 'startingDate'
         },
         {
             Header:'Degradation Rate',
             //accessor: row => row.startingDate.toString(),
-            accessor: row => String(row.degradationRate),
+            accessor: row => String(row.commons.degradationRate),
             id: 'degradationRate'
         },
         {
             Header:'Show Leaderboard?',
             id: 'showLeaderboard', // needed for tests
-            accessor: (row, _rowIndex) => String(row.showLeaderboard) // hack needed for boolean values to show up
+            accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
+        },
+        {
+            Header: 'Cows',
+            accessor: 'totalCows'
         }
     ];
 

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -31,43 +31,42 @@ export default function CommonsTable({ commons, currentUser }) {
     const columns = [
         {
             Header: 'id',
-            accessor: 'commons.id', // accessor is the "key" in the data
+            accessor: 'id', // accessor is the "key" in the data
 
         },
         {
             Header:'Name',
-            accessor: 'commons.name',
+            accessor: 'name',
         },
         {
             Header:'Cow Price',
-            accessor: row => String(row.commons.cowPrice),
+            accessor: row => row.cowPrice,
             id: 'cowPrice'
         },
         {
             Header:'Milk Price',
-            accessor: row => String(row.commons.milkPrice),
+            accessor: row => row.milkPrice,
             id: 'milkPrice'
         },
         {
             Header:'Starting Balance',
-            accessor: row => String(row.commons.startingBalance),
+            accessor: row => row.startingBalance,
             id: 'startingBalance'
         },
         {
             Header:'Starting Date',
-            accessor: row => String(row.commons.startingDate).slice(0,10),
+            accessor: row => String(row.startingDate).slice(0,10),
             id: 'startingDate'
         },
         {
             Header:'Degradation Rate',
-            //accessor: row => row.startingDate.toString(),
-            accessor: row => String(row.commons.degradationRate),
+            accessor: row => row.degradationRate,
             id: 'degradationRate'
         },
         {
             Header:'Show Leaderboard?',
             id: 'showLeaderboard', // needed for tests
-            accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
+            accessor: (row, _rowIndex) => String(row.showLeaderboard) // hack needed for boolean values to show up
         },
         {
             Header: 'Cows',

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -11,8 +11,8 @@ export default function AdminListCommonsPage()
   // Stryker disable  all 
   const { data: commons, error: _error, status: _status } =
     useBackend(
-      ["/api/commons/all"],
-      { method: "GET", url: "/api/commons/all" },
+      ["/api/commons/allplus"],
+      { method: "GET", url: "/api/commons/allplus" },
       []
     );
   // Stryker enable  all 

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -49,7 +49,7 @@ describe("AdminListCommonPage tests", () => {
     test("renders without crashing for regular user", () => {
         setupUserOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, []);
+        axiosMock.onGet("/api/commons/allplus").reply(200, []);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -63,7 +63,7 @@ describe("AdminListCommonPage tests", () => {
     test("renders without crashing for admin user", () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, []);
+        axiosMock.onGet("/api/commons/allplus").reply(200, []);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -77,7 +77,7 @@ describe("AdminListCommonPage tests", () => {
     test("renders three commons without crashing for admin user", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -96,7 +96,7 @@ describe("AdminListCommonPage tests", () => {
         setupUserOnly();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").timeout();
+        axiosMock.onGet("/api/commons/allplus").timeout();
 
         const restoreConsole = mockConsole();
 
@@ -118,7 +118,7 @@ describe("AdminListCommonPage tests", () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
         axiosMock.onDelete("/api/commons", {params: {id: 5}}).reply(200, "Commons with id 5 was deleted");
 
         render(
@@ -144,7 +144,7 @@ describe("AdminListCommonPage tests", () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -168,7 +168,7 @@ describe("AdminListCommonPage tests", () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
 
         render(
             <QueryClientProvider client={queryClient}>

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.ArrayList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
@@ -54,9 +56,74 @@ public class CommonsController extends ApiController {
   @GetMapping("/all")
   public ResponseEntity<String> getCommons() throws JsonProcessingException {
     log.info("getCommons()...");
-    Iterable<Commons> users = commonsRepository.findAll();
-    String body = mapper.writeValueAsString(users);
+    Iterable<Commons> commons = commonsRepository.findAll();
+    String body = mapper.writeValueAsString(commons);
     return ResponseEntity.ok().body(body);
+  }
+
+  // @ApiOperation(value = "Get a list of all commons and number of cows/users")
+  // @GetMapping("/allplus")
+  // public Iterable<CommonsPlus> getCommonsPlus() throws JsonProcessingException {
+  //   log.info("getCommonsPlus()...");
+  //   Iterable<Commons> commonsList = commonsRepository.findAll();
+    
+  //   ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>();
+
+  //  // NOTE: the following can probably be done much more efficiently using Java Streams 
+  // // and functional programming that uses a lambda to map a commons to a commonsPlus
+
+  //   for (Commons c : commonsList) {
+  //      Integer numCows = 0;
+  //      Long commonsId = c.getId();
+  //      Optional<Integer> numberOfCows = commonsRepository.getNumCows(commonsId);
+
+  //      if (numberOfCows.isPresent()) {
+  //        numCows = numberOfCows.get();
+  //      } 
+       
+  //      //int numUsers = commonsRepository.getNumUsers(c.id);
+  //      //commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+  //      commonsPlusList.add( new CommonsPlus(c, numCows, commonsId));
+  //   }    
+
+  // return commonsPlusList;
+
+  // }
+
+  @ApiOperation(value = "Get a list of all commons and number of cows/users")
+  @GetMapping("/allplus")
+  public ResponseEntity<String> getCommonsPlus() throws JsonProcessingException {
+    log.info("getCommonsPlus()...");
+    Iterable<Commons> commonsList = commonsRepository.findAll();
+    
+    ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>();
+
+   // NOTE: the following can probably be done much more efficiently using Java Streams 
+  // and functional programming that uses a lambda to map a commons to a commonsPlus
+
+    for (Commons c : commonsList) {
+       Integer numCows = 0;
+       Integer numUsers = 0;
+       Long commonsId = c.getId();
+       Optional<Integer> numberOfCows = commonsRepository.getNumCows(commonsId);
+       Optional<Integer> numberOfUsers = commonsRepository.getNumUsers(commonsId);
+
+       if (numberOfCows.isPresent()) {
+         numCows = numberOfCows.get();
+       } 
+
+       if (numberOfUsers.isPresent()) {
+         numUsers = numberOfUsers.get();
+       } 
+       
+       //int numUsers = commonsRepository.getNumUsers(c.id);
+       //commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+       commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+    }
+
+    String body = mapper.writeValueAsString(commonsPlusList);
+    return ResponseEntity.ok().body(body);
+    // return commonsPlusList;
   }
 
   @ApiOperation(value = "Update a commons")

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommonsPlus {
+    private Commons commons;
+    private Integer totalCows;
+    private Integer totalUsers;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -4,11 +4,17 @@ import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 
 
 @Repository
 public interface CommonsRepository extends CrudRepository<Commons, Long> {
+    @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
+    Optional<Integer> getNumCows(Long commonsId);
 
+    @Query("SELECT COUNT(uc.userId) FROM user_commons uc WHERE uc.commonsId=:commonsId")
+    Optional<Integer> getNumUsers(Long commonsId);
+    
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -714,4 +714,40 @@ public class CommonsControllerTests extends ControllerTestCase {
     }
   }
 
+  
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void getCommonsPlusTest() throws Exception {
+    List<Commons> expectedCommons = new ArrayList<Commons>();
+    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+    expectedCommons.add(Commons1);
+
+    List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
+    List<CommonsPlus> dummy = new ArrayList<CommonsPlus>();
+    CommonsPlus CommonsPlus1 = CommonsPlus.builder()
+          .commons(Commons1)
+          .totalCows(50)
+          .totalUsers(20)
+          .build();
+
+    expectedCommonsPlus.add(CommonsPlus1);
+    when(commonsRepository.findAll()).thenReturn(expectedCommons);
+    when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
+    when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+
+    MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    //verify(commonsRepository, times(1)).findAll();
+    verify(commonsRepository, times(1)).findAll();
+    verify(commonsRepository, times(1)).getNumCows(1L);
+    verify(commonsRepository, times(1)).getNumUsers(1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString, new TypeReference<List<CommonsPlus>>() {
+    });
+    assertEquals(actualCommonsPlus, expectedCommonsPlus);
+  }
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -37,6 +37,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
+
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -13,13 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 import java.util.Map;
 
@@ -39,7 +39,6 @@ import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
-import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
@@ -714,8 +713,6 @@ public class CommonsControllerTests extends ControllerTestCase {
     }
   }
 
-  
-
   @WithMockUser(roles = { "USER" })
   @Test
   public void getCommonsPlusTest() throws Exception {
@@ -726,10 +723,10 @@ public class CommonsControllerTests extends ControllerTestCase {
     List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
     List<CommonsPlus> dummy = new ArrayList<CommonsPlus>();
     CommonsPlus CommonsPlus1 = CommonsPlus.builder()
-          .commons(Commons1)
-          .totalCows(50)
-          .totalUsers(20)
-          .build();
+        .commons(Commons1)
+        .totalCows(50)
+        .totalUsers(20)
+        .build();
 
     expectedCommonsPlus.add(CommonsPlus1);
     when(commonsRepository.findAll()).thenReturn(expectedCommons);
@@ -742,8 +739,9 @@ public class CommonsControllerTests extends ControllerTestCase {
     verify(commonsRepository, times(1)).findAll();
 
     String responseString = response.getResponse().getContentAsString();
-    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString, new TypeReference<List<CommonsPlus>>() {
-    });
+    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
+        new TypeReference<List<CommonsPlus>>() {
+        });
     assertEquals(actualCommonsPlus, expectedCommonsPlus);
   }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -739,10 +739,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
         .andExpect(status().isOk()).andReturn();
 
-    //verify(commonsRepository, times(1)).findAll();
     verify(commonsRepository, times(1)).findAll();
-    verify(commonsRepository, times(1)).getNumCows(1L);
-    verify(commonsRepository, times(1)).getNumUsers(1L);
 
     String responseString = response.getResponse().getContentAsString();
     List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString, new TypeReference<List<CommonsPlus>>() {


### PR DESCRIPTION
see: https://github.com/ucsb-cs156-s22/s22-6pm-happycows/pull/114

# Overview

In this PR, we create a new object CommonsPlus that, in addition to a given commons, contains two additional fields: `totalCows` and `totalUsers`. 

We add a SQL query to query the user commons table for the two values of interest (total number of cows and users in a commons) and a corresponding endpoint/api route to return the CommonsPlus objects with the number of cows/users.

We refactor the implementation of the getCommonsPlus method in CommonsController to use functional programming (java streams with lambdas), making the implementation of this method straightforward and efficient. 

Demonstrating the `api/commons/allplus` endpoint:
<img width="1427" alt="Screen Shot 2022-07-11 at 5 38 21 PM" src="https://user-images.githubusercontent.com/72824248/178381748-80cfdfab-03c4-4a5f-b29b-017acbebe8b6.png">

Closes #112 #102 and #98 

Further testing will be done on Heroku QA deployment.