### PR TITLE
pc -  add placeholder code to calculate profits from milking the cows (and simplify ProfitsController)

### DIFF
--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -19,13 +19,21 @@ export default function ProfitsTable({ profits }) {
     const memoizedColumns = React.useMemo(() => 
         [
             {
-                Header: "Profit",
-                accessor: "profit",
+                Header: "Amount",
+                accessor: (row) => `\$${row.amount.toFixed(2)}`,
             },
             {
                 Header: "Date",
                 accessor: "date",
-            }
+            },
+            {
+                Header: "CowHealth",
+                accessor: "avgCowHealth",
+            },
+            {
+                Header: "NumCows",
+                accessor: "numCows",
+            },
         ], 
     []);
     const memoizedDates = React.useMemo(() => profits, [profits]);

--- a/frontend/src/main/components/Jobs/MilkCowsJobForm.js
+++ b/frontend/src/main/components/Jobs/MilkCowsJobForm.js
@@ -1,8 +1,22 @@
-function MilkCowsJobForm() {
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function MilkTheCowsForm( {submitAction} ) {
+
+    // Stryker disable all
+    const {
+      handleSubmit,
+    } = useForm(
+    );
+    // Stryker enable all
+
     return (
-      <p>This will be the Milk Cow Job Function. (Coming soon)</p>
+      <Form onSubmit={handleSubmit(submitAction)}>
+        <p>Click this button to update cows' health in all commons!</p>
+        <Button type="submit" data-testid="MilkTheCowsForm-Submit-Button">Update</Button>
+    </Form>
     );
   }
   
-  export default MilkCowsJobForm;
+  export default MilkTheCowsForm;
   

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -45,6 +45,8 @@ const AdminJobsPage = () => {
         );
     // Stryker enable  all
 
+    // UpdateCowHealth job
+
     const objectToAxiosParamsUpdateCowHealthJob = () => ({
         url: `/api/jobs/launch/updatecowhealth`,
         method: "POST"
@@ -63,14 +65,38 @@ const AdminJobsPage = () => {
         UpdateCowHealthMutation.mutate();
     }
 
+    // MilkTheCows job
+
+    const objectToAxiosParamsMilkTheCowsJob = () => ({
+        url: `/api/jobs/launch/milkthecowjob`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const MilkTheCowsMutation = useBackendMutation(
+        objectToAxiosParamsMilkTheCowsJob,
+        {  },
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitMilkTheCowsJob = async () => {
+        console.log("submitMilkTheCowsJob")
+        MilkTheCowsMutation.mutate();
+    }
+
     const jobLaunchers = [
+        {
+            name: "Test Job",
+            form:  <TestJobForm submitAction={submitTestJob} />
+        },
         {
             name: "Update Cow Health",
             form: <UpdateCowHealthForm submitAction={submitUpdateCowHealthJob}/>
         },
         {
             name: "Milk The Cows",
-            form: <MilkCowsJobForm />
+            form: <MilkCowsJobForm submitAction={submitMilkTheCowsJob}/>
         },
         {
             name: "Instructor Report",
@@ -80,17 +106,12 @@ const AdminJobsPage = () => {
 
     return (
         <BasicLayout>
+
             <h2 className="p-3">Launch Jobs</h2>
             <Accordion>
-                <Accordion.Item eventKey="0">
-                    <Accordion.Header>Test Job</Accordion.Header>
-                    <Accordion.Body>
-                        <TestJobForm submitAction={submitTestJob} />
-                    </Accordion.Body>
-                </Accordion.Item>
                 {
                     jobLaunchers.map((jobLauncher, index) => (
-                        <Accordion.Item eventKey={index + 1}>
+                        <Accordion.Item eventKey={index}>
                             <Accordion.Header>{jobLauncher.name}</Accordion.Header>
                             <Accordion.Body>
                                 {jobLauncher.form}
@@ -101,8 +122,8 @@ const AdminJobsPage = () => {
             </Accordion>
 
             <h2 className="p-3">Job Status</h2>
-
             <JobsTable jobs={jobs} />
+
         </BasicLayout>
     );
 };

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -79,32 +79,57 @@ describe("AdminJobsPage tests", () => {
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
         expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/testjob?fail=false&sleepMs=0");
-});
+    });
 
-test("user can update cow healath", async () => {
-    render(
-        <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-                <AdminJobsPage />
-            </MemoryRouter>
-        </QueryClientProvider>
-    );
+    test("user can submit update cow health job", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    expect(await screen.findByText("Update Cow Health")).toBeInTheDocument();
+        expect(await screen.findByText("Update Cow Health")).toBeInTheDocument();
 
-    const UpdateCowHealthJobButton = screen.getByText("Update Cow Health");
-    expect(UpdateCowHealthJobButton).toBeInTheDocument();
-    UpdateCowHealthJobButton.click();
+        const UpdateCowHealthJobButton = screen.getByText("Update Cow Health");
+        expect(UpdateCowHealthJobButton).toBeInTheDocument();
+        UpdateCowHealthJobButton.click();
 
-    const submitButton = screen.getByTestId("UpdateCowHealthForm-Submit-Button");
+        const submitButton = screen.getByTestId("UpdateCowHealthForm-Submit-Button");
 
-    expect(submitButton).toBeInTheDocument();
-    submitButton.click();
+        expect(submitButton).toBeInTheDocument();
+        submitButton.click();
 
-    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
-    expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/updatecowhealth");
-});
+        expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/updatecowhealth");
+    });
+
+    test("user can submit milk the cows job", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Milk The Cows")).toBeInTheDocument();
+
+        const MilkTheCowsJobButton = screen.getByText("Milk The Cows");
+        expect(MilkTheCowsJobButton).toBeInTheDocument();
+        MilkTheCowsJobButton.click();
+
+        const submitButton = screen.getByTestId("MilkTheCowsForm-Submit-Button");
+
+        expect(submitButton).toBeInTheDocument();
+        submitButton.click();
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/milkthecowjob");
+    });
 
 
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -41,7 +41,7 @@ describe("PlayPage tests", () => {
                 name: "Sample Commons"
             }
         ]);
-        axiosMock.onGet("/api/profits/all/commons").reply(200, []);
+        axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
         axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
         axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
     });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJob;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJob;
+import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
@@ -45,6 +46,10 @@ public class JobsController extends ApiController {
 
     @Autowired
     UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
+    @Autowired
+    MilkTheCowsJobFactory milkTheCowsJobFactory;
+
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -74,7 +79,7 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/milkthecowjob")
     public Job launchTestJob(
     ) {
-        MilkTheCowsJob milkTheCowsJob = MilkTheCowsJob.builder().build();
+        MilkTheCowsJob milkTheCowsJob = milkTheCowsJobFactory.create();
         return jobService.runAsJob(milkTheCowsJob);
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -50,7 +50,6 @@ public class JobsController extends ApiController {
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
 
-
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/all")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -16,6 +16,9 @@ import io.swagger.annotations.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.Valid;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -48,108 +51,6 @@ public class ProfitsController extends ApiController {
 
     @Autowired
     ProfitRepository profitRepository;
-
-    @ApiOperation(value = "Get a single profit for user")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("")
-    public Profit getProfitById(
-            @ApiParam("id") @RequestParam Long id) {
-        Long userId = getCurrentUser().getUser().getId();
-
-        Profit profit = profitRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Profit.class, id));
-        if (userId != profit.getUserCommons().getUserId())
-            throw new EntityNotFoundException(Profit.class, id);
-        return profit;
-    }
-
-    @ApiOperation(value = "Get a single profit for admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/admin")
-    public Profit getProfitById_admin(
-            @ApiParam("id") @RequestParam Long id) {
-        Profit profit = profitRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Profit.class, id));
-        return profit;
-    }
-
-    @ApiOperation(value = "List all profits")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/admin/all")
-    public Iterable<Profit> allUsersProfits() {
-        Iterable<Profit> profits = profitRepository.findAll();
-        return profits;
-    }
-
-    @ApiOperation(value = "Get all profits belonging to a user commons as a user")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("/all/commons")
-    public Iterable<Profit> allProfitsByUserCommonsId(
-            @ApiParam("userCommonsId") @RequestParam Long userCommonsId) {
-        Long userId = getCurrentUser().getUser().getId();
-
-        UserCommons userCommons = userCommonsRepository.findById(userCommonsId).orElseThrow(() -> new EntityNotFoundException(UserCommons.class, userCommonsId));
-
-        if (userId != userCommons.getUserId())
-            throw new EntityNotFoundException(UserCommons.class, userCommonsId);
-
-        Iterable<Profit> profits = profitRepository.findAllByUserCommonsId(userCommonsId);
-
-        return profits;
-    }
-
-    @ApiOperation(value = "Get all profits belonging to a user commons as an admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/admin/all/commons")
-    public Iterable<Profit> allProfitsByUserCommonsId_admin(
-            @ApiParam("userCommonsId") @RequestParam Long userCommonsId) {
-        Iterable<Profit> profits = profitRepository.findAllByUserCommonsId(userCommonsId);
-        return profits;
-    }
-
-    @ApiOperation(value = "Create a new Profit as admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/admin/post")
-    public Profit postProfit_admin(
-            @ApiParam("profit") @RequestParam long profit,
-            @ApiParam("timestamp") @RequestParam long timestamp,
-            @ApiParam("userCommonsId") @RequestParam long userCommonsId) {
-        UserCommons userCommons = userCommonsRepository.findById(userCommonsId).orElseThrow(() -> new EntityNotFoundException(UserCommons.class, userCommonsId));
-
-        Profit createdProfit = new Profit();
-        createdProfit.setProfit(profit);
-        createdProfit.setUserCommons(userCommons);
-        createdProfit.setTimestamp(timestamp);
-        Profit savedProfit = profitRepository.save(createdProfit);
-        return savedProfit;
-    }
-
-
-    @ApiOperation(value = "Delete other user profit as admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/admin")
-    public Object deleteProfit_Admin(
-            @ApiParam("id") @RequestParam Long id) {
-        Profit profit = profitRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Profit.class, id));
-
-        profitRepository.delete(profit);
-
-        return genericMessage("Profit with id %s deleted".formatted(id));
-    }
-
-    @ApiOperation(value = "Update a single profit as admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("/admin")
-    public Profit putProfitById_admin(
-            @ApiParam("id") @RequestParam Long id,
-            @RequestBody @Valid Profit newProfit) {
-        Profit profit = profitRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Profit.class, id));
-
-        profit.setProfit(newProfit.getProfit());
-        profit.setTimestamp(newProfit.getTimestamp());
-
-        profitRepository.save(profit);
-
-        return profit;
-    }
 
     @ApiOperation(value = "Get all profits belonging to a user commons as a user via CommonsID")
     @PreAuthorize("hasRole('ROLE_USER')")

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Profit.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Profit.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.happiercows.entities;
 
+import java.time.LocalDateTime;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -27,6 +29,8 @@ public class Profit {
     @JoinColumn(name = "user_commons_id")
     
     private UserCommons userCommons;
-    private long profit;
-    private long timestamp;
+    private double profit;
+    private LocalDateTime timestamp;
+    private int numCows;
+    private double avgCowHealth;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Profit.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Profit.java
@@ -27,9 +27,9 @@ public class Profit {
 
     @ManyToOne
     @JoinColumn(name = "user_commons_id")
-    
+
     private UserCommons userCommons;
-    private double profit;
+    private double amount;
     private LocalDateTime timestamp;
     private int numCows;
     private double avgCowHealth;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -32,7 +32,7 @@ public class MilkTheCowsJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
-            ctx.log("Milking cows for Commons: " + commons.getName());
+            ctx.log("Milking cows for Commons: " + commons.getName() + ", Milk Price: $" + String.format("%.2f",commons.getMilkPrice()));
 
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
@@ -40,8 +40,8 @@ public class MilkTheCowsJob implements JobContextConsumer {
                 User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
                 ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
 
-                double profit = calculateMilkingProfit(userCommons);
-                ctx.log("Profit for user: " + user.getFullName() + " is: " + profit);
+                double profit = calculateMilkingProfit(commons, userCommons);
+                ctx.log("Profit for user: " + user.getFullName() + " is: $" + String.format("%.2f",profit));
             }
         }
 
@@ -53,8 +53,9 @@ public class MilkTheCowsJob implements JobContextConsumer {
      * @param userCommons
      * @return
      */
-    public static double calculateMilkingProfit(UserCommons userCommons) {
-        double profit = userCommons.getNumOfCows() * userCommons.getCowHealth();
+    public static double calculateMilkingProfit(Commons commons, UserCommons userCommons) {
+        double milkPrice = commons.getMilkPrice();
+        double profit = userCommons.getNumOfCows() * (userCommons.getCowHealth() / 100.0) * milkPrice;
         return profit;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
@@ -21,6 +22,8 @@ public class MilkTheCowsJob implements JobContextConsumer {
     private UserCommonsRepository userCommonsRepository;
     @Getter
     private UserRepository userRepository;
+    @Getter
+    private ProfitRepository profitRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
@@ -37,12 +40,21 @@ public class MilkTheCowsJob implements JobContextConsumer {
                 User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
                 ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
 
-                ctx.log("Logic to milk the cows for user: " + user.getFullName() + " will go here");
-
-                // TODO: Milk the cows, and report profits.
+                double profit = calculateMilkingProfit(userCommons);
+                ctx.log("Profit for user: " + user.getFullName() + " is: " + profit);
             }
         }
 
         ctx.log("Cows have been milked!");
+    }
+
+    /**
+     * Calculate the profit for a user from milking their cows.  
+     * @param userCommons
+     * @return
+     */
+    public static double calculateMilkingProfit(UserCommons userCommons) {
+        double profit = userCommons.getNumOfCows() * userCommons.getCowHealth();
+        return profit;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -1,11 +1,24 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
+@AllArgsConstructor
 @Builder
 public class MilkTheCowsJob implements JobContextConsumer {
+
+    @Getter
+    private CommonsRepository commonsRepository;
+    @Getter
+    private UserCommonsRepository userCommonsRepository;
+    @Getter
+    private UserRepository userRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -1,5 +1,8 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
@@ -10,7 +13,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor
-@Builder
 public class MilkTheCowsJob implements JobContextConsumer {
 
     @Getter
@@ -23,7 +25,24 @@ public class MilkTheCowsJob implements JobContextConsumer {
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Starting to milk the cows");
-        ctx.log("This is where the code to milk the cows will go.");
+
+        Iterable<Commons> allCommons = commonsRepository.findAll();
+
+        for (Commons commons : allCommons) {
+            ctx.log("Milking cows for Commons: " + commons.getName());
+
+            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
+
+            for (UserCommons userCommons : allUserCommons) {
+                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
+                ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
+
+                ctx.log("Logic to milk the cows for user: " + user.getFullName() + " will go here");
+
+                // TODO: Milk the cows, and report profits.
+            }
+        }
+
         ctx.log("Cows have been milked!");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
@@ -4,27 +4,32 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
-public class MilkTheCowsJobFactory  {
+public class MilkTheCowsJobFactory {
 
-    @Autowired 
+    @Autowired
     private CommonsRepository commonsRepository;
-  
+
     @Autowired
     private UserCommonsRepository userCommonsRepository;
 
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private ProfitRepository profitRepository;
+
     public MilkTheCowsJob create() {
-        log.info("userRepository = " + userRepository);
-        log.info("commonsRepository = " + commonsRepository);
-        log.info("userCommonsRepository = " + userCommonsRepository);
-        return new MilkTheCowsJob(commonsRepository, userCommonsRepository, userRepository);
+        return new MilkTheCowsJob(
+                commonsRepository,
+                userCommonsRepository,
+                userRepository,
+                profitRepository);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MilkTheCowsJobFactory  {
+
+    @Autowired 
+    private CommonsRepository commonsRepository;
+  
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public MilkTheCowsJob create() {
+        log.info("userRepository = " + userRepository);
+        log.info("commonsRepository = " + commonsRepository);
+        log.info("userCommonsRepository = " + userCommonsRepository);
+        return new MilkTheCowsJob(commonsRepository, userCommonsRepository, userRepository);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-@Slf4j
 public class UpdateCowHealthJob implements JobContextConsumer {
 
     @Getter

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobService.java
@@ -6,8 +6,6 @@ import edu.ucsb.cs156.happiercows.services.CurrentUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,7 +20,6 @@ public class JobService {
   @Autowired
   private JobService self;
 
-
   public Job runAsJob(JobContextConsumer jobFunction) {
     Job job = Job.builder()
       .createdBy(currentUserService.getUser())
@@ -34,12 +31,9 @@ public class JobService {
     return job;
   }
 
-  
-
   @Async
   public void runJobAsync(Job job, JobContextConsumer jobFunction) {
     JobContext context = new JobContext(jobsRepository, job);
-
 
     try {
       jobFunction.accept(context);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -191,6 +191,7 @@ public class JobsControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void admin_can_launch_milk_the_cows_job() throws Exception {
+        
         // act
         MvcResult response = mockMvc.perform(post("/api/jobs/launch/milkthecowjob").with(csrf()))
                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -38,7 +38,7 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
-import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
+import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
@@ -71,6 +71,8 @@ public class JobsControllerTests extends ControllerTestCase {
     @MockBean
     UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
+    @MockBean
+    MilkTheCowsJobFactory milkTheCowsJobFactory;
 
     @WithMockUser(roles = { "ADMIN" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -10,7 +10,6 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -25,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -63,156 +63,63 @@ public class ProfitsControllerTests extends ControllerTestCase {
   @MockBean
   CommonsRepository commonsRepository;
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin() throws Exception {
+  UserCommons uc1 = UserCommons.builder().id(1).commonsId(2).userId(1).build();
+  UserCommons uc2 = UserCommons.builder().id(2).commonsId(2).userId(2).build();
 
-    List<Profit> testProfits = new ArrayList<Profit>();
+  LocalDateTime t1 = LocalDateTime.parse("2022-03-05T15:50:10");
+  LocalDateTime t2 = LocalDateTime.parse("2022-03-05T15:50:11");
+  LocalDateTime t3 = LocalDateTime.parse("2022-03-05T15:50:12");
 
-    UserCommons uc1 = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    UserCommons uc2 = UserCommons.builder().id(1).commonsId(2).userId(2).build();
-
-    Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(uc1).build();
-    Profit p2 = Profit.builder().id(43).profit(200).timestamp(12).userCommons(uc1).build();
-    Profit p3 = Profit.builder().id(44).profit(300).timestamp(12).userCommons(uc2).build();
-
-    testProfits.add(p1);
-    testProfits.add(p2);
-    testProfits.add(p3);
-    when(profitRepository.findAll()).thenReturn(testProfits);
-
-    MvcResult response = mockMvc.perform(get("/api/profits/admin/all")).andExpect(status().isOk()).andReturn();
-    
-    verify(profitRepository, times(1)).findAll();
-    
-    String responseString = response.getResponse().getContentAsString();
-    List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {});
-    assertEquals(actualProfits, testProfits);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin2() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit expectedProfit = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-    when(profitRepository.findById(42L)).thenReturn(Optional.of(expectedProfit));
-
-    MvcResult response = mockMvc.perform(get("/api/profits/admin?id=42")).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-
-    String responseString = response.getResponse().getContentAsString();
-    Profit actualProfit = objectMapper.readValue(responseString, Profit.class);
-    assertEquals(actualProfit, expectedProfit);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void get_profits() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit expectedProfit = Profit.builder().id(36L).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-    when(profitRepository.findById(36L)).thenReturn(Optional.of(expectedProfit));
-
-    MvcResult response = mockMvc.perform(get("/api/profits?id=36")).andExpect(status().isOk()).andReturn();
-    verify(profitRepository, times(1)).findById(36L);
-
-    String responseString = response.getResponse().getContentAsString();
-    Profit actualProfit = objectMapper.readValue(responseString, Profit.class);
-    assertEquals(actualProfit, expectedProfit);
-  }
+  Profit p1 = Profit.builder().id(41).profit(123.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
+  Profit p2 = Profit.builder().id(42).profit(543.21).timestamp(t2).userCommons(uc1).numCows(2).avgCowHealth(90).build();
+  Profit p3 = Profit.builder().id(43).profit(567.89).timestamp(t3).userCommons(uc2).numCows(3).avgCowHealth(100)
+      .build();
 
   @WithMockUser(roles = { "USER" })
   @Test
-  public void get_profits_user() throws Exception {
-
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(100).build();
-    Profit expectedProfit = Profit.builder().id(36L).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    when(profitRepository.findById(36L)).thenReturn(Optional.of(expectedProfit));
-
-    MvcResult response = mockMvc.perform(get("/api/profits?id=36")).andExpect(status().isNotFound()).andReturn();
-
-    verify(profitRepository, times(1)).findById(36L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("Profit with id 36 not found", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void get_profits_not_found() throws Exception {
-    MvcResult response = mockMvc.perform(get("/api/profits?id=36")).andExpect(status().isNotFound()).andReturn();
-
-    verify(profitRepository, times(1)).findById(36L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("Profit with id 36 not found", json.get("message"));
-  }
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin_user() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(100).build();
-    Profit expectedProfit = Profit.builder().id(36).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-    when(profitRepository.findById(36L)).thenReturn(Optional.of(expectedProfit));
-
-    MvcResult response = mockMvc.perform(get("/api/profits/admin?id=36")).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(36L);
-
-    String responseString = response.getResponse().getContentAsString();
-    Profit actualProfit = objectMapper.readValue(responseString, Profit.class);
-    assertEquals(actualProfit, expectedProfit);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin_not_found() throws Exception {
-    MvcResult response = mockMvc.perform(get("/api/profits/admin?id=36")).andExpect(status().isNotFound()).andReturn();
-
-    verify(profitRepository, times(1)).findById(36L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("Profit with id 36 not found", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void get_profits_all_commons() throws Exception {
+  public void get_profits_all_commons_using_commons_id() throws Exception {
     List<Profit> expectedProfits = new ArrayList<Profit>();
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
+    UserCommons expectedUserCommons = p1.getUserCommons();
     expectedProfits.add(p1);
     when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-    when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(expectedUserCommons));
 
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1")).andDo(print()).andExpect(status().isOk()).andReturn();
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2")).andDo(print())
+        .andExpect(status().isOk()).andReturn();
 
     verify(profitRepository, times(1)).findAllByUserCommonsId(1L);
 
     String responseString = response.getResponse().getContentAsString();
-    List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {});
+    List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {
+    });
     assertEquals(actualProfits, expectedProfits);
   }
 
   @WithMockUser(roles = { "USER" })
   @Test
-  public void get_profits_all_commons_other_user() throws Exception {
+  public void get_profits_all_commons_other_user_using_commons_id() throws Exception {
     List<Profit> expectedProfits = new ArrayList<Profit>();
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(2).build();
-    Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
+    UserCommons expectedUserCommons = UserCommons.builder()
+        .id(1)
+        .commonsId(2)
+        .userId(2).build();
+    Profit p1 = Profit.builder()
+        .id(42)
+        .profit(543.21)
+        .timestamp(LocalDateTime.parse("2022-03-05T15:50:11"))
+        .userCommons(uc1)
+        .numCows(2)
+        .avgCowHealth(90)
+        .build();
+    expectedProfits.add(p1);
 
     when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-    when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(expectedUserCommons));
 
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2").contentType("application/json"))
+        .andExpect(status().isNotFound()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findById(1L);
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
@@ -221,241 +128,16 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "USER" })
   @Test
-  public void get_profits_all_commons_nonexistent() throws Exception {
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
+  public void get_profits_all_commons_nonexistent_using_commons_id() throws Exception {
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2").contentType("application/json"))
+        .andExpect(status().isNotFound()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findById(1L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with id 1 not found", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin_all_commons() throws Exception {
-    List<Profit> expectedProfits = new ArrayList<Profit>();
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    expectedProfits.add(p1);
-    when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-
-    MvcResult response = mockMvc.perform(get("/api/profits/admin/all/commons?userCommonsId=1").contentType("application/json")).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findAllByUserCommonsId(1L);
-
-    String responseString = response.getResponse().getContentAsString();
-    List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {});
-    assertEquals(actualProfits, expectedProfits);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void get_profits_admin_all_commons_other_user() throws Exception {
-    List<Profit> expectedProfits = new ArrayList<Profit>();
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(2).build();
-    Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    expectedProfits.add(p1);
-    when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-
-    MvcResult response = mockMvc.perform(get("/api/profits/admin/all/commons?userCommonsId=1")).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findAllByUserCommonsId(1L);
-
-    String responseString = response.getResponse().getContentAsString();
-    List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {});
-    assertEquals(actualProfits, expectedProfits);
-  }
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void post_profits_admin_post() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit expectedProfit = Profit.builder().id(0).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    when(profitRepository.save(expectedProfit)).thenReturn(expectedProfit);
-    when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
-
-    MvcResult response = mockMvc.perform(post("/api/profits/admin/post?profit=100&timestamp=12&userCommonsId=1").with(csrf())).andDo(print()).andExpect(status().isOk()).andReturn();
-
-    verify(userCommonsRepository, times(1)).findById(1L);
-    verify(profitRepository, times(1)).save(expectedProfit);
-
-    String expectedJson = mapper.writeValueAsString(expectedProfit);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void delete_profits_admin() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit p = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    when(profitRepository.findById(42L)).thenReturn(Optional.of(p));
-
-    MvcResult response = mockMvc.perform(delete("/api/profits/admin?id=42").with(csrf())).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-    verify(profitRepository, times(1)).delete(p);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("Profit with id 42 deleted", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void delete_profits_admin_other_user() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(100).build();
-    Profit p = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    when(profitRepository.findById(42L)).thenReturn(Optional.of(p));
-
-    MvcResult response = mockMvc.perform(delete("/api/profits/admin?id=42").with(csrf())).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-    verify(profitRepository, times(1)).delete(p);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("Profit with id 42 deleted", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void put_profits_admin() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-    Profit before = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-    Profit after = Profit.builder().id(42).profit(200).timestamp(14).userCommons(expectedUserCommons).build();
-
-    String requestBody = mapper.writeValueAsString(after);
-    String expectedReturn = mapper.writeValueAsString(after);
-
-    when(profitRepository.findById(42L)).thenReturn(Optional.of(before));
-
-    MvcResult response = mockMvc.perform(put("/api/profits/admin?id=42").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-    verify(profitRepository, times(1)).save(after);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedReturn, responseString);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void put_profits_admin_other_user() throws Exception {
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(100).build();
-    Profit p = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-
-    String requestBody = mapper.writeValueAsString(p);
-    String expectedReturn = mapper.writeValueAsString(p);
-
-    when(profitRepository.findById(42L)).thenReturn(Optional.of(p));
-
-    MvcResult response = mockMvc.perform(put("/api/profits/admin?id=42").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-    verify(profitRepository, times(1)).save(p);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedReturn, responseString);
-  }
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void put_profits_admin_not_found() throws Exception {
-    UserCommons expectedUC = UserCommons.builder().id(1).commonsId(2).userId(100).build();
-    Profit profit = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUC).build();
-
-    String requestBody = mapper.writeValueAsString(profit);
-
-    MvcResult response = mockMvc.perform(put("/api/profits/admin?id=42").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-    verify(profitRepository, times(0)).save(profit);
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("Profit with id 42 not found", json.get("message"));
+    assertEquals("UserCommons with commonsId 2 and userId 1 not found",
+        json.get("message"));
   }
-
-  
-
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void delete_profits_admin_not_found() throws Exception {
-    MvcResult response = mockMvc.perform(delete("/api/profits/admin?id=42").with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-    verify(profitRepository, times(1)).findById(42L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("Profit with id 42 not found", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void post_profits_admin_post_not_found() throws Exception {
-    MvcResult response = mockMvc.perform(post("/api/profits/admin/post?profit=100&timestamp=12&userCommonsId=1").with(csrf())).andDo(print()).andExpect(status().isNotFound()).andReturn();
-    verify(userCommonsRepository, times(1)).findById(1L);
-
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with id 1 not found", json.get("message"));
-  }
-
-
-@WithMockUser(roles = { "USER" })
-@Test
-public void get_profits_all_commons_using_commons_id() throws Exception {
-  List<Profit> expectedProfits = new ArrayList<Profit>();
-  UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
-  Profit p1 = Profit.builder().id(36).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-  expectedProfits.add(p1);
-  when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-  when(userCommonsRepository.findByCommonsIdAndUserId(2L,1L)).thenReturn(Optional.of(expectedUserCommons));
-
-  MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2")).andDo(print()).andExpect(status().isOk()).andReturn();
-
-  verify(profitRepository, times(1)).findAllByUserCommonsId(1L);
-
-  String responseString = response.getResponse().getContentAsString();
-  List<Profit> actualProfits = objectMapper.readValue(responseString, new TypeReference<List<Profit>>() {});
-  assertEquals(actualProfits, expectedProfits);
-}
-
-@WithMockUser(roles = { "USER" })
-@Test
-public void get_profits_all_commons_other_user_using_commons_id() throws Exception {
-  List<Profit> expectedProfits = new ArrayList<Profit>();
-  UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(2).build();
-  Profit p1 = Profit.builder().id(36).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
-  when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-  when(userCommonsRepository.findByCommonsIdAndUserId(2L,1L)).thenReturn(Optional.of(expectedUserCommons));
-
-  MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
-
-  verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L,1L);
-
-  Map<String, Object> json = responseToJson(response);
-  assertEquals("EntityNotFoundException", json.get("type"));
-  assertEquals("UserCommons with id 1 not found", json.get("message"));
-}
-
-@WithMockUser(roles = { "USER" })
-@Test
-public void get_profits_all_commons_nonexistent_using_commons_id() throws Exception {
-  MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
-
-  verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L,1L);
-
-  Map<String, Object> json = responseToJson(response);
-  assertEquals("EntityNotFoundException", json.get("type"));
-  assertEquals("UserCommons with commonsId 2 and userId 1 not found", json.get("message"));
-}
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -70,9 +70,9 @@ public class ProfitsControllerTests extends ControllerTestCase {
   LocalDateTime t2 = LocalDateTime.parse("2022-03-05T15:50:11");
   LocalDateTime t3 = LocalDateTime.parse("2022-03-05T15:50:12");
 
-  Profit p1 = Profit.builder().id(41).profit(123.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
-  Profit p2 = Profit.builder().id(42).profit(543.21).timestamp(t2).userCommons(uc1).numCows(2).avgCowHealth(90).build();
-  Profit p3 = Profit.builder().id(43).profit(567.89).timestamp(t3).userCommons(uc2).numCows(3).avgCowHealth(100)
+  Profit p1 = Profit.builder().id(41).amount(123.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
+  Profit p2 = Profit.builder().id(42).amount(543.21).timestamp(t2).userCommons(uc1).numCows(2).avgCowHealth(90).build();
+  Profit p3 = Profit.builder().id(43).amount(567.89).timestamp(t3).userCommons(uc2).numCows(3).avgCowHealth(100)
       .build();
 
   @WithMockUser(roles = { "USER" })
@@ -105,7 +105,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
         .userId(2).build();
     Profit p1 = Profit.builder()
         .id(42)
-        .profit(543.21)
+        .amount(543.21)
         .timestamp(LocalDateTime.parse("2022-03-05T15:50:11"))
         .userCommons(uc1)
         .numCows(2)

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 
@@ -26,6 +27,9 @@ public class MilkTheCowsJobFactoryTests {
     @MockBean
     UserRepository userRepository;
 
+    @MockBean
+    ProfitRepository profitRepository;
+
     @Autowired
     MilkTheCowsJobFactory MilkTheCowsJobFactory;
 
@@ -39,6 +43,7 @@ public class MilkTheCowsJobFactoryTests {
         assertEquals(commonsRepository,MilkTheCowsJob.getCommonsRepository());
         assertEquals(userCommonsRepository,MilkTheCowsJob.getUserCommonsRepository());
         assertEquals(userRepository,MilkTheCowsJob.getUserRepository());
+        assertEquals(profitRepository,MilkTheCowsJob.getProfitRepository());
 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+
+@RestClientTest(MilkTheCowsJobFactory.class)
+@AutoConfigureDataJpa
+public class MilkTheCowsJobFactoryTests {
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    MilkTheCowsJobFactory MilkTheCowsJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        MilkTheCowsJob MilkTheCowsJob = MilkTheCowsJobFactory.create();
+
+        // Assert
+        assertEquals(commonsRepository,MilkTheCowsJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,MilkTheCowsJob.getUserCommonsRepository());
+        assertEquals(userRepository,MilkTheCowsJob.getUserRepository());
+
+    }
+}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -19,6 +19,7 @@ import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
@@ -34,6 +35,9 @@ public class MilkTheCowsJobTests {
 
     @Mock
     UserRepository userRepository;
+
+    @Mock
+    ProfitRepository profitRepository;
 
     private User user = User
             .builder()
@@ -52,7 +56,7 @@ public class MilkTheCowsJobTests {
 
         // Act
         MilkTheCowsJob milkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
-                userRepository);
+                userRepository, profitRepository);
 
         milkTheCowsJob.accept(ctx);
 
@@ -103,7 +107,7 @@ public class MilkTheCowsJobTests {
 
         // Act
         MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
-                userRepository);
+                userRepository, profitRepository);
         MilkTheCowsJob.accept(ctx);
 
         // Assert
@@ -112,7 +116,7 @@ public class MilkTheCowsJobTests {
                 Starting to milk the cows
                 Milking cows for Commons: test commons
                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
-                Logic to milk the cows for user: Chris Gaucho will go here
+                Profit for user: Chris Gaucho is: 10.0
                 Cows have been milked!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -157,7 +161,7 @@ public class MilkTheCowsJobTests {
 
             // Act
             MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
-                            userRepository);
+                            userRepository, profitRepository);
 
             RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
                     // Code under test

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -114,9 +114,9 @@ public class MilkTheCowsJobTests {
 
         String expected = """
                 Starting to milk the cows
-                Milking cows for Commons: test commons
+                Milking cows for Commons: test commons, Milk Price: $2.00
                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
-                Profit for user: Chris Gaucho is: 10.0
+                Profit for user: Chris Gaucho is: $0.20
                 Cows have been milked!""";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -3,11 +3,30 @@ package edu.ucsb.cs156.happiercows.jobs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
 public class MilkTheCowsJobTests {
+    @Mock
+    CommonsRepository commonsRepository;
+
+    @Mock
+    UserCommonsRepository userCommonsRepository;
+
+    @Mock
+    UserRepository userRepository;
+
     @Test
     void test_log_output() throws Exception {
 
@@ -17,14 +36,14 @@ public class MilkTheCowsJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         // Act
-        MilkTheCowsJob milkTheCowsJob = MilkTheCowsJob.builder()
-                .build();
+        MilkTheCowsJob milkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
+                userRepository);
+
         milkTheCowsJob.accept(ctx);
 
         // Assert
 
         String expected = "Starting to milk the cows\n" +
-                "This is where the code to milk the cows will go.\n" +
                 "Cows have been milked!";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -1,14 +1,22 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
@@ -27,8 +35,15 @@ public class MilkTheCowsJobTests {
     @Mock
     UserRepository userRepository;
 
+    private User user = User
+            .builder()
+            .id(1L)
+            .fullName("Chris Gaucho")
+            .email("cgaucho@example.org")
+            .build();
+
     @Test
-    void test_log_output() throws Exception {
+    void test_log_output_no_commons() throws Exception {
 
         // Arrange
 
@@ -43,10 +58,114 @@ public class MilkTheCowsJobTests {
 
         // Assert
 
-        String expected = "Starting to milk the cows\n" +
-                "Cows have been milked!";
+        String expected = """
+                Starting to milk the cows
+                Cows have been milked!""";
 
         assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_commons_and_user_commons() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(10)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                .thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // Act
+        MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
+                userRepository);
+        MilkTheCowsJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Starting to milk the cows
+                Milking cows for Commons: test commons
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                Logic to milk the cows for user: Chris Gaucho will go here
+                Cows have been milked!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_throws_exception_when_getting_user_fails() throws Exception {
+
+            // Arrange
+            Job jobStarted = Job.builder().build();
+            JobContext ctx = new JobContext(null, jobStarted);
+
+            UserCommons origUserCommons = UserCommons
+                            .builder()
+                            .id(1L)
+                            .userId(321L)
+                            .commonsId(1L)
+                            .totalWealth(300)
+                            .numOfCows(1)
+                            .cowHealth(10)
+                            .build();
+
+            Commons testCommons = Commons
+                            .builder()
+                            .id(117L)
+                            .name("test commons")
+                            .cowPrice(10)
+                            .milkPrice(2)
+                            .startingBalance(300)
+                            .startingDate(LocalDateTime.now())
+                            .carryingCapacity(100)
+                            .degradationRate(0.01)
+                            .build();
+
+            Commons commonsTemp[] = { testCommons };
+            UserCommons userCommonsTemp[] = { origUserCommons };
+            when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+            when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                            .thenReturn(Arrays.asList(userCommonsTemp));
+            when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(10));
+            when(userRepository.findById(321L)).thenReturn(Optional.empty());
+
+            // Act
+            MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
+                            userRepository);
+
+            RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+                    // Code under test
+                    MilkTheCowsJob.accept(ctx);
+            });
+
+            Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
 
     }
+
 }


### PR DESCRIPTION
In this PR, we add code into the MilkTheCows job that will calculate profits from milking the cows.

This may or may not be the precise formula that  Prof. de Vries will want to end up with,  but it's a good start; and it demonstrates that we can update profits based on number of cows and cow health.

We also simplify the ProfitsController; previous developers had built full CRUD operations, but probably the only thing we need in the frontend (at least for now) is the ability to get profits for a single user based on specifying their commonsId.  This is what's used to populate the play page; no other endpoints of the Profits controller were actually being called in the code.

We also update the `Profit` model to contain information on the number of cows and the cow health that was present at the time the cows were milked, and we modify the time stamp to be a LocalDateTime object.