### PR TITLE
pc - add scheduled jobs

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/HappierCowsApplication.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/HappierCowsApplication.java
@@ -9,15 +9,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
-
-
-import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
 @SpringBootApplication
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
 @EnableAsync
+@EnableScheduling
 public class HappierCowsApplication {
   public static void main(String[] args) {
     SpringApplication.run(HappierCowsApplication.class, args);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -26,6 +26,7 @@ import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 
 
@@ -78,7 +79,7 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/milkthecowjob")
     public Job launchTestJob(
     ) {
-        MilkTheCowsJob milkTheCowsJob = milkTheCowsJobFactory.create();
+        JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
         return jobService.runAsJob(milkTheCowsJob);
     }
 
@@ -87,7 +88,7 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/updatecowhealth")
     public Job updateCowHealth(
     ) { 
-        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+        JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
         return jobService.runAsJob(updateCowHealthJob);
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactory.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
@@ -21,7 +22,7 @@ public class MilkTheCowsJobFactory  {
     @Autowired
     private UserRepository userRepository;
 
-    public MilkTheCowsJob create() {
+    public JobContextConsumer create() {
         log.info("userRepository = " + userRepository);
         log.info("commonsRepository = " + commonsRepository);
         log.info("userCommonsRepository = " + userCommonsRepository);

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -1,0 +1,50 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import edu.ucsb.cs156.happiercows.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+@Component("scheduledJobs")
+@Slf4j
+public class ScheduledJobs {
+
+    @Autowired
+    private JobService jobService;
+
+    @Autowired
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
+    @Autowired
+    MilkTheCowsJobFactory milkTheCowsJobFactory;
+    
+    @Scheduled(cron = "${app.updateCowHealth.cron}")
+    public void runUpdateCowHealthJobBasedOnCron() {
+       log.info("runUpdateCowHealthJobBasedOnCron: running");
+
+       UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+       jobService.runAsJob(updateCowHealthJob);
+    
+       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
+    }
+
+    // /**
+    //  * A job that runs every ten seconds, as an example
+    //  */
+
+    // @Scheduled(cron = "*/10 * * * * * ")
+    // public void everyTenSeconds() {
+    //    log.info("everyTenSeconds: running");
+    // }
+
+    @Scheduled(cron = "${app.milkTheCows.cron}")
+    public void runMilkTheCowsJobBasedOnCron() {
+       log.info("runMilkTheCowsJobBasedOnCron: running");
+
+       MilkTheCowsJob milkTheCowsJob = milkTheCowsJobFactory.create();
+       jobService.runAsJob(milkTheCowsJob);
+    
+       log.info("runMilkTheCowsJobBasedOnCron: launched job");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -3,6 +3,8 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,7 +38,7 @@ public class ScheduledJobs {
     public void runUpdateCowHealthJobBasedOnCron() {
        log.info("runUpdateCowHealthJobBasedOnCron: running");
 
-       UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+       JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
        jobService.runAsJob(updateCowHealthJob);
     
        log.info("runUpdateCowHealthJobBasedOnCron: launched job");
@@ -46,7 +48,7 @@ public class ScheduledJobs {
     public void runMilkTheCowsJobBasedOnCron() {
        log.info("runMilkTheCowsJobBasedOnCron: running");
 
-       MilkTheCowsJob milkTheCowsJob = milkTheCowsJobFactory.create();
+       JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
        jobService.runAsJob(milkTheCowsJob);
     
        log.info("runMilkTheCowsJobBasedOnCron: launched job");

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -6,6 +6,19 @@ import org.springframework.stereotype.Component;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class contains methods that are scheduled to run at certain times
+ * to launch particular jobs.
+ * 
+ * The value of the <code>cron</code> parameter to the <code>&#64;Scheduled</code>
+ * annotation is a Spring Boot cron expression, which is similar to
+ * a Unix cron expression, but with an extra field at the beginning for
+ * the seconds.
+ * 
+ * @See <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html">Spring Cron Syntax</a>
+ * 
+ */
+
 @Component("scheduledJobs")
 @Slf4j
 public class ScheduledJobs {
@@ -28,15 +41,6 @@ public class ScheduledJobs {
     
        log.info("runUpdateCowHealthJobBasedOnCron: launched job");
     }
-
-    // /**
-    //  * A job that runs every ten seconds, as an example
-    //  */
-
-    // @Scheduled(cron = "*/10 * * * * * ")
-    // public void everyTenSeconds() {
-    //    log.info("everyTenSeconds: running");
-    // }
 
     @Scheduled(cron = "${app.milkTheCows.cron}")
     public void runMilkTheCowsJobBasedOnCron() {

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
  * a Unix cron expression, but with an extra field at the beginning for
  * the seconds.
  * 
- * @See <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html">Spring Cron Syntax</a>
+ * @see <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html">Spring Cron Syntax</a>
  * 
  */
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -3,9 +3,11 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
@@ -21,7 +23,7 @@ public class UpdateCowHealthJobFactory  {
     @Autowired
     private UserRepository userRepository;
 
-    public UpdateCowHealthJob create() {
+    public JobContextConsumer create() {
         log.info("commonsRepository = " + commonsRepository);
         log.info("userCommonsRepository = " + userCommonsRepository);
         return new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,11 @@ server.compression.enabled=false
 
 spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
 
+# Use https://crontab.guru/ to translate the expressions below
+# except that there is an additional field at the beginning for seconds
+
+# app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:* * 0,12 * * *}}
+# app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:* * 4 * * *}}
+
+app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 */3 * * * *}}
+app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 */5 * * * *}}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
@@ -33,12 +33,12 @@ public class MilkTheCowsJobFactoryTests {
     void test_create() throws Exception {
 
         // Act
-        MilkTheCowsJob MilkTheCowsJob = MilkTheCowsJobFactory.create();
+        MilkTheCowsJob milkTheCowsJob = (MilkTheCowsJob) MilkTheCowsJobFactory.create();
 
         // Assert
-        assertEquals(commonsRepository,MilkTheCowsJob.getCommonsRepository());
-        assertEquals(userCommonsRepository,MilkTheCowsJob.getUserCommonsRepository());
-        assertEquals(userRepository,MilkTheCowsJob.getUserRepository());
+        assertEquals(commonsRepository,milkTheCowsJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,milkTheCowsJob.getUserCommonsRepository());
+        assertEquals(userRepository,milkTheCowsJob.getUserRepository());
 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.happiercows.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+// @Slf4j
+// @ExtendWith(SpringExtension.class)
+// @ContextConfiguration 
+
+@RestClientTest(ScheduledJobs.class)
+@AutoConfigureDataJpa
+public class ScheduledJobsTests {
+
+    private class MockJobContextConsumer implements JobContextConsumer {
+        @Override
+        public void accept(JobContext jobContext) {}
+    }
+
+    @MockBean
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
+    @MockBean
+    MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+    @Autowired
+    private ScheduledJobs scheduledJobs;
+
+    @MockBean
+    private JobService jobService;
+
+    @Test
+    void test_runUpdateCowHealthJobBasedOnCron() throws Exception {
+
+        // Arrange
+
+        Job job = Job.builder().build();
+        MockJobContextConsumer mockJob = new MockJobContextConsumer();
+
+       when(updateCowHealthJobFactory.create()).thenReturn(mockJob);
+       when(jobService.runAsJob(any())).thenReturn(job);
+
+        // Act
+
+        scheduledJobs.runUpdateCowHealthJobBasedOnCron();
+
+        // Assert
+
+        verify(jobService, times(1)).runAsJob(mockJob);
+        verify(updateCowHealthJobFactory, times(1)).create();
+
+    }
+
+    @Test
+    void test_runMilkTheCowsJobBasedOnCron() throws Exception {
+
+        // Arrange
+
+        Job job = Job.builder().build();
+        MockJobContextConsumer mockJob = new MockJobContextConsumer();
+
+       when(milkTheCowsJobFactory.create()).thenReturn(mockJob);
+       when(jobService.runAsJob(any())).thenReturn(job);
+
+        // Act
+
+        scheduledJobs.runMilkTheCowsJobBasedOnCron();
+
+        // Assert
+
+        verify(jobService, times(1)).runAsJob(mockJob);
+        verify(milkTheCowsJobFactory, times(1)).create();
+
+    }
+
+  
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -33,7 +33,7 @@ public class UpdateCowHealthJobFactoryTests {
     void test_create() throws Exception {
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+        UpdateCowHealthJob updateCowHealthJob = (UpdateCowHealthJob) updateCowHealthJobFactory.create();
 
         // Assert
         assertEquals(commonsRepository,updateCowHealthJob.getCommonsRepository());


### PR DESCRIPTION
In this PR, we add scheduled jobs to the app using cron syntax.

Cron scheduling allows us to schedule jobs (e.g. milking the cows, updating cow health, or producing reports) at fixed intervals, or fixed dates, and times of day, using [Spring Boot cron syntax](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html)

From the documentation linked above, Spring Boot cron syntax looks like this:

```
 ┌───────────── second (0-59)
 │ ┌───────────── minute (0 - 59)
 │ │ ┌───────────── hour (0 - 23)
 │ │ │ ┌───────────── day of the month (1 - 31)
 │ │ │ │ ┌───────────── month (1 - 12) (or JAN-DEC)
 │ │ │ │ │ ┌───────────── day of the week (0 - 7)
 │ │ │ │ │ │          (0 or 7 is Sunday, or MON-SUN)
 │ │ │ │ │ │
 * * * * * *
```

Note that Spring Boot cron syntax is slightly different from Unix cron syntax, in that it has an extra seconds field at the start.

The two jobs that we add are one to milk the cows, and another to update cow health.

The environment variables used to control the schedule are:
* `app.updateCowHealth.cron` (default value `0 30 */1 * * *` which will update cow health at 30 minutes after the hour every hour.)
* `app.milkTheCows.cron` (default value `0 0 4 * * * ` which will milk the cows every day at 4:00am)

These can be set for debugging to something like `0 */5 * * * *` to run the job every minutes.

To avoid race conditions, it is advisable to change the first value (for seconds) to 30 when testing if you are setting up both jobs to run, as well as using relatively prime values, e.g.

```
UPDATE_COW_HEALTH_CRON="0 */5 * * * *"
MILK_THE_COWS_CRON="30 */7 * * * *"
```

This means the two jobs will only run during the minute every 35 minutes, and even then they will be offset by at least 30 seconds.
