### PR TITLE
Pc report jobs

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -123,7 +123,7 @@ jobs:
   build-pitest-main:
     name: d - Pitest (main)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: [initialize]
     env:
       destination: target/pit-reports
@@ -394,6 +394,7 @@ jobs:
   d-build-pitest-for-each-pr:
     name: d - Pitest (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ needs.initialize.outputs.pull_requests != '[]' && needs.initialize.outputs.pull_requests != '' }}
 
     needs: [initialize]

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3.5.2

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3.5.2

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
@@ -1,17 +1,9 @@
 package edu.ucsb.cs156.happiercows.entities;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import javax.persistence.*;
-
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
-import lombok.AccessLevel;
 
 @Data
 @AllArgsConstructor
@@ -21,5 +13,4 @@ public class CommonsPlus {
     private Commons commons;
     private Integer totalCows;
     private Integer totalUsers;
-
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Report.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Report.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "reports")
+public class Report {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private long commons_id;
+    private String name;
+    private double cowPrice;
+    private double milkPrice;
+    private double startingBalance;
+    private LocalDateTime startingDate;
+    private boolean showLeaderboard;
+    private int carryingCapacity;
+    private double degradationRate;
+
+    // these defaults match old behavior
+    @Enumerated(EnumType.STRING)
+    private CowHealthUpdateStrategies belowCapacityHealthUpdateStrategy;
+    @Enumerated(EnumType.STRING)
+    private CowHealthUpdateStrategies aboveCapacityHealthUpdateStrategy;
+    private int numUsers;
+    private int numCows;
+
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "create_date")
+    private Date createDate;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "report_lines")
+
+public class ReportLine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private long report_id;
+    private long user_id;
+    private String username;
+    private double totalWealth;
+    private int numOfCows;
+    private double avgCowHealth;
+    private int cowsBought;
+    private int cowsSold;
+    private int cowDeaths;
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "create_date")
+    private Date createDate;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -18,7 +18,7 @@ public class UserCommons {
     @EmbeddedId
     @JsonIgnore
     @Builder.Default
-    private final UserCommonsKey id = new UserCommonsKey();
+    private UserCommonsKey id = new UserCommonsKey();
 
     @MapsId("userId")
     @ManyToOne
@@ -53,5 +53,12 @@ public class UserCommons {
     @JsonInclude
     public long getCommonsId() {
         return commons.getId();
+    }
+
+    public void setId(UserCommonsKey id) {
+        this.id = id;
+    }
+     public UserCommonsKey getId() {
+        return this.id;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactory.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.ReportService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+
+@Service
+public class InstructorReportJobFactory {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private CommonsRepository commonsRepository;
+
+    public JobContextConsumer create() {
+        return new InstructorReportJob(reportService, commonsRepository);
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
@@ -16,31 +16,25 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 
 import edu.ucsb.cs156.happiercows.services.ReportService;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @AllArgsConstructor
-public class InstructorReportJob implements JobContextConsumer {
+public class InstructorReportJobSingleCommons implements JobContextConsumer {
+
+    @Getter
+    private long commonsId;
 
     @Getter
     private ReportService reportService;
-
-    @Getter
-    private CommonsRepository commonsRepository;
-
+    
     @Override
     public void accept(JobContext ctx) throws Exception {
-        ctx.log("Starting instructor report...");
-        Iterable<Commons> allCommons = commonsRepository.findAll();
-
-        for (Commons commons : allCommons) {
-            ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
-            Report report = reportService.createReport(commons.getId());
-            ctx.log(String.format("Report %d for commons id=%d (%s) finished.", report.getId(), commons.getId(),
-                    commons.getName()));
-        }
-        ctx.log("Instructor report done!");
+        ctx.log("Producing instructor report for commons id: " + commonsId);
+        Report report = reportService.createReport(commonsId);
+        ctx.log(String.format("Instructor report %d for commons %s has been produced!", report.getId(), report.getName()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactory.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.services.ReportService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+
+@Service
+public class InstructorReportJobSingleCommonsFactory {
+
+    @Autowired
+    private ReportService reportService;
+
+    public JobContextConsumer create(long commonsId) {
+        return new InstructorReportJobSingleCommons(commonsId, reportService);
+    }
+  
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportLineRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportLineRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import edu.ucsb.cs156.happiercows.entities.ReportLine;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportLineRepository extends CrudRepository<ReportLine, Long> {
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import edu.ucsb.cs156.happiercows.entities.Report;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends CrudRepository<Report, Long> {
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
@@ -1,0 +1,83 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.Report;
+import edu.ucsb.cs156.happiercows.entities.ReportLine;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+@Service("ReportService")
+public class ReportService {
+
+    @Autowired
+    ReportRepository reportRepository;
+
+    @Autowired
+    ReportLineRepository reportLineRepository;
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    public Report createReport(Long commons_id) {
+        Report report = createAndSaveReportHeader(commons_id);
+        
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons_id);
+
+        for (UserCommons userCommons : allUserCommons) {
+               createAndSaveReportLine(report, userCommons);
+        }
+
+        return report;
+    }
+
+    public Report createAndSaveReportHeader(Long commons_id) {
+        Commons commons = commonsRepository.findById(commons_id)
+                .orElseThrow(() -> new RuntimeException(String.format("Commons with id %d not found", commons_id)));
+
+        Report report = Report.builder()
+                .commons_id(commons_id)
+                .name(commons.getName())
+                .cowPrice(commons.getCowPrice())
+                .milkPrice(commons.getMilkPrice())
+                .startingBalance(commons.getStartingBalance())
+                .startingDate(commons.getStartingDate())
+                .showLeaderboard(commons.isShowLeaderboard())
+                .carryingCapacity(commons.getCarryingCapacity())
+                .degradationRate(commons.getDegradationRate())
+                .belowCapacityHealthUpdateStrategy(commons.getBelowCapacityHealthUpdateStrategy())
+                .aboveCapacityHealthUpdateStrategy(commons.getAboveCapacityHealthUpdateStrategy())
+                .numUsers(commonsRepository.getNumUsers(commons_id).orElse(0))
+                .numCows(commonsRepository.getNumCows(commons_id).orElse(0))
+                .build();
+
+        reportRepository.save(report);
+        return report;
+    }
+
+    public ReportLine createAndSaveReportLine(Report report, UserCommons userCommons) {
+        ReportLine reportLine = ReportLine.builder()
+                .report_id(report.getId())
+                .user_id(userCommons.getUser().getId())
+                .username(userCommons.getUsername())
+                .totalWealth(userCommons.getTotalWealth())
+                .numOfCows(userCommons.getNumOfCows())
+                .avgCowHealth(userCommons.getCowHealth())
+                .cowsBought(userCommons.getCowsBought())
+                .cowsSold(userCommons.getCowsSold())
+                .cowDeaths(userCommons.getCowDeaths())
+                .build();
+
+        reportLineRepository.save(reportLine);
+        return reportLine;
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CSRFControllerTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -14,7 +13,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
@@ -25,4 +25,24 @@ public class UserCommonsTests {
         assertEquals(5L, asMap.get("commonsId"));
         assertEquals(10L, asMap.get("userId"));
     }
+
+    @Test
+    void userCommons_setId() {
+        // arrange
+        var userCommons = UserCommons.builder()
+                .commons(Commons.builder().id(5L).build())
+                .user(User.builder().id(10L).build())
+                .cowHealth(50)
+                .totalWealth(100)
+                .build();
+        
+        // act 
+
+        var newUserCommonsKey = new UserCommonsKey(20L, 30L);
+        userCommons.setId(newUserCommonsKey);
+        
+        // assert again
+        assertEquals(newUserCommonsKey, userCommons.getId());
+
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.ReportService;
+
+@RestClientTest(InstructorReportJobFactory.class)
+@AutoConfigureDataJpa
+public class InstructorReportJobFactoryTests {
+
+    @MockBean
+    ReportService reportService;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    InstructorReportJobFactory InstructorReportJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        InstructorReportJob InstructorReportJob = (InstructorReportJob) InstructorReportJobFactory.create();
+
+        // Assert
+        assertEquals(reportService,InstructorReportJob.getReportService());
+        assertEquals(commonsRepository,InstructorReportJob.getCommonsRepository());
+       
+    }
+}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
@@ -9,10 +9,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 
 @RestClientTest(InstructorReportJobSingleCommonsFactory.class)

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.ReportService;
+
+@RestClientTest(InstructorReportJobSingleCommonsFactory.class)
+@AutoConfigureDataJpa
+public class InstructorReportJobSingleCommonsFactoryTests {
+
+    @MockBean
+    ReportService reportService;
+ 
+    @Autowired
+    InstructorReportJobSingleCommonsFactory InstructorReportJobSingleCommonsFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        InstructorReportJobSingleCommons instructorReportJobSingleCommons = (InstructorReportJobSingleCommons) InstructorReportJobSingleCommonsFactory.create(17L);
+
+        // Assert
+        assertEquals(17L,instructorReportJobSingleCommons.getCommonsId());
+        assertEquals(reportService,instructorReportJobSingleCommons.getReportService());
+    }
+}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
@@ -23,42 +23,34 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class InstructorReportJobTests {
+public class InstructorReportJobSingleCommonsTests {
 
     @MockBean
     ReportService reportService;
-
-    @MockBean
-    CommonsRepository commonsRepository;
 
     @Test
     void test_log_output() throws Exception {
 
         // Arrange
 
-        Commons commons= Commons.builder().id(17L).name("CS156").build();
-        Report report = Report.builder().id(17L).build();
+        Report report = Report.builder().id(17L).name("Foo").build();
         
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
       
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
         when(reportService.createReport(17L)).thenReturn(report);
 
         // Act
-        InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
-        instructorReportJob.accept(ctx);
+        InstructorReportJobSingleCommons InstructorReportJobSingleCommons = new InstructorReportJobSingleCommons(17L, reportService);
+        InstructorReportJobSingleCommons.accept(ctx);
 
         // Assert
 
-        verify(commonsRepository).findAll();
         verify(reportService).createReport(17L);
         
         String expected = """
-            Starting instructor report...
-            Starting Commons id=17 (CS156)...
-            Report 17 for commons id=17 (CS156) finished.
-            Instructor report done!""";
+            Producing instructor report for commons id: 17
+            Instructor report 17 for commons Foo has been produced!""";
 
         assertEquals(expected, jobStarted.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -144,11 +145,12 @@ class ReportServiceTests {
 
         // act
 
-        reportService.createAndSaveReportHeader(17L);
+        Report report = reportService.createAndSaveReportHeader(17L);
 
         // // assert
 
         verify(reportRepository).save(eq(expectedReportHeader));
+        assertEquals(expectedReportHeader, report);
   }
 
   @Test
@@ -181,10 +183,11 @@ class ReportServiceTests {
 
         // act
 
-        reportService.createReport(17L);
+        Report report = reportService.createReport(17L);
 
         // assert
 
+        assertEquals(expectedReportHeader, report);
         verify(reportLineRepository).save(eq(expectedReportLine));
         verify(reportLineRepository).save(eq(expectedReportLine));
   }
@@ -202,9 +205,11 @@ class ReportServiceTests {
 
         // act
 
-        reportService.createAndSaveReportLine(expectedReportHeader, userCommons);
+        ReportLine reportLine = reportService.createAndSaveReportLine(expectedReportHeader, userCommons);
 
         // assert
+
+        assertEquals(expectedReportLine, reportLine);
 
         verify(reportLineRepository).save(eq(expectedReportLine));
   }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -1,0 +1,212 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import javax.persistence.Column;
+import javax.persistence.Enumerated;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.Report;
+import edu.ucsb.cs156.happiercows.entities.ReportLine;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.UserCommonsKey;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+@ExtendWith(SpringExtension.class)
+@Import(ReportService.class)
+@ContextConfiguration
+class ReportServiceTests {
+
+  @MockBean
+  UserRepository userRepository;
+
+  @MockBean
+  CommonsRepository commonsRepository;
+
+  @MockBean
+  UserCommonsRepository userCommonsRepository;
+
+  @MockBean
+  ReportRepository reportRepository;
+
+  @MockBean
+  ReportLineRepository reportLineRepository;
+
+  @Autowired
+  ReportService reportService;
+
+  private User user = User
+      .builder()
+      .id(42L)
+      .fullName("Chris Gaucho")
+      .email("cgaucho@example.org")
+      .build();
+
+  private Commons commons = Commons
+      .builder()
+      .id(17L)
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+      .showLeaderboard(true)
+      .carryingCapacity(100)
+      .degradationRate(0.01)
+      .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .build();
+
+  UserCommons userCommons = UserCommons
+      .builder()
+      .user(user)
+      .username("Chris Gaucho")
+      .commons(commons)
+      .totalWealth(300)
+      .numOfCows(123)
+      .cowHealth(10)
+      .cowsBought(78)
+      .cowsSold(23)
+      .cowDeaths(6)
+      .build();
+
+  Report expectedReportHeader = Report.builder()
+      .name("test commons")
+      .commons_id(17L)
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+      .showLeaderboard(true)
+      .carryingCapacity(100)
+      .degradationRate(0.01)
+      .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .numCows(123)
+      .numUsers(1)
+      .build();
+
+  ReportLine expectedReportLine = ReportLine.builder()
+      .user_id(42L)
+      .username("Chris Gaucho")
+      .totalWealth(300)
+      .numOfCows(123)
+      .avgCowHealth(10)
+      .cowsBought(78)
+      .cowsSold(23)
+      .cowDeaths(6)
+      .build();
+
+  @BeforeEach
+  void setup() {
+    userCommons.setId(new UserCommonsKey(user.getId(), commons.getId()));
+  }
+
+  @Test
+  void test_createAndSaveReportHeader() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId()))
+                .thenReturn(Arrays.asList(userCommons));
+        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+
+        // act
+
+        reportService.createAndSaveReportHeader(17L);
+
+        // // assert
+
+        verify(reportRepository).save(eq(expectedReportHeader));
+  }
+
+  @Test
+  void test_createAndSaveReportHeader_throwsException() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.empty());
+
+        // act / assert
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            reportService.createAndSaveReportHeader(17L);
+        }, "RuntimeException was expected");
+
+        String message = thrown.getMessage();
+        String expectedMessage = "Commons with id 17 not found";
+        Assertions.assertTrue(message.contains(expectedMessage), String.format("Expected message to contain \"%s\" but was \"%s\"", expectedMessage, message));
+  }
+
+  @Test
+  void test_createAndSaveReport() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId()))
+                .thenReturn(Arrays.asList(userCommons));
+        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+
+        // act
+
+        reportService.createReport(17L);
+
+        // assert
+
+        verify(reportLineRepository).save(eq(expectedReportLine));
+        verify(reportLineRepository).save(eq(expectedReportLine));
+  }
+
+  @Test
+  void test_createAndSaveReportLine() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId()))
+                .thenReturn(Arrays.asList(userCommons));
+        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+
+        // act
+
+        reportService.createAndSaveReportLine(expectedReportHeader, userCommons);
+
+        // assert
+
+        verify(reportLineRepository).save(eq(expectedReportLine));
+  }
+
+}


### PR DESCRIPTION
# Overview

In this PR, we add jobs that can take use the ReportsService to produce instructor reports (for now, only in the database).

A future PR will add controller methods to launch the job and to retrieve the Report data.