### PR TITLE
Pc reports page

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,7 @@
 import "bootstrap/dist/css/bootstrap.css";
 import 'react-toastify/dist/ReactToastify.css';
 import "../src/index.css";
+import { initialize, mswDecorator } from 'msw-storybook-addon';
 
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,6 +9,18 @@ import { MemoryRouter } from "react-router-dom";
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
 }
+
+const currentUrl = window.location.href;
+const isLocalhost = currentUrl.startsWith("http://localhost:6006/");
+const mockServiceWorkerUrl = isLocalhost ? "mockServiceWorker.js" : "https://" + window.location.hostname + "/mockServiceWorker.js";
+
+initialize(
+  {
+    serviceWorker: {
+      url: mockServiceWorkerUrl
+    }
+  }
+);
 
 const queryClient = new QueryClient();
 
@@ -18,9 +31,15 @@ const queryClient = new QueryClient();
 export const decorators = [
   (Story) => (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      {/* 
+          The initialEntries must be modified to include the
+          expected path for any stories that
+          rely on the useParams hook, e.g. AdminViewReportPage
+       */}
+      <MemoryRouter initialEntries={['/admin/report/108', '/leaderboard/17']}>
         <Story />
       </MemoryRouter>
     </QueryClientProvider>
   ),
+  mswDecorator, // provide the MSW decorator globally
 ];

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -31,12 +31,7 @@ const queryClient = new QueryClient();
 export const decorators = [
   (Story) => (
     <QueryClientProvider client={queryClient}>
-      {/* 
-          The initialEntries must be modified to include the
-          expected path for any stories that
-          rely on the useParams hook, e.g. AdminViewReportPage
-       */}
-      <MemoryRouter initialEntries={['/admin/report/108', '/leaderboard/17']}>
+      <MemoryRouter>
         <Story />
       </MemoryRouter>
     </QueryClientProvider>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,8 @@
         "eslint-plugin-react": "^7.30.0",
         "jest-mock-console": "^1.1.0",
         "jest-watch-typeahead": "^0.6.5",
+        "msw": "^1.2.3",
+        "msw-storybook-addon": "^1.8.0",
         "react-test-renderer": "^17.0.2"
       },
       "engines": {
@@ -3680,6 +3682,47 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
+      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3749,6 +3792,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.4",
@@ -11328,6 +11377,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -11454,6 +11518,12 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -11482,6 +11552,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -11641,6 +11717,15 @@
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "dependencies": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
+      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -12266,6 +12351,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -12275,6 +12369,13 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -12888,6 +12989,18 @@
       "funding": {
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axe-core": {
@@ -19065,6 +19178,15 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -19525,13 +19647,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -19740,10 +19863,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+    },
+    "node_modules/graphql": {
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
+      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -19856,6 +20000,17 @@
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20115,6 +20270,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "node_modules/highlight.js": {
       "version": "10.7.3",
@@ -21179,6 +21340,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -21236,6 +21412,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -21400,6 +21582,21 @@
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dependencies": {
         "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
@@ -24225,6 +24422,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -25347,6 +25553,382 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.3.tgz",
+      "integrity": "sha512-Fqy/TaLKR32x4IkMwudJHJysBzVM/v/lSoMPS9f3QaHLOmb3xHN9YurSUnRt+2eEvNXLjVPij1wMBQtLmTbKsg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.2",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.4.x <= 5.1.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.8.0.tgz",
+      "integrity": "sha512-dw3vZwqjixmiur0vouRSOax7wPSu9Og2Hspy9JZFHf49bZRjwDiLF0Pfn2NXEkGviYJOJiGxS1ejoTiUwoSg4A==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": ">=0.35.0 <2.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/msw/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -26146,6 +26728,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true
     },
     "node_modules/overlayscrollbars": {
       "version": "1.13.1",
@@ -31076,6 +31664,12 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -31936,6 +32530,12 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -34295,6 +34895,31 @@
       "integrity": "sha512-V8X6hPIzY1juvrSVREmtRhK9AHn/8c2z8XxaibESU+jyG/RinZ9x9x6aw8qEuFAi7R6Kl/EWGbU2Yq/9u6TTjw==",
       "dev": true
     },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      }
+    },
+    "node_modules/web-encoding/node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
@@ -34873,6 +35498,25 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -37926,6 +38570,43 @@
         }
       }
     },
+    "@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "requires": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "@mswjs/interceptors": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
+      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "dev": true,
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "dependencies": {
+        "strict-event-emitter": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+          "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+          "dev": true,
+          "requires": {
+            "events": "^3.3.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -37979,6 +38660,12 @@
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.4",
@@ -43724,6 +44411,21 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -43850,6 +44552,12 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -43878,6 +44586,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -44039,6 +44753,15 @@
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "requires": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/set-cookie-parser": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
+      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -44556,6 +45279,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -44565,6 +45294,13 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "abab": {
       "version": "2.0.5",
@@ -45035,6 +45771,12 @@
         "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
       }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
     },
     "axe-core": {
       "version": "4.4.1",
@@ -49782,6 +50524,15 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -50158,13 +50909,14 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -50309,10 +51061,25 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+    },
+    "graphql": {
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
+      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "dev": true
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -50398,6 +51165,11 @@
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -50588,6 +51360,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "highlight.js": {
       "version": "10.7.3",
@@ -51349,6 +52127,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -51384,6 +52171,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+    },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -51491,6 +52284,15 @@
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "requires": {
+        "which-typed-array": "^1.1.11"
       }
     },
     "is-typedarray": {
@@ -53594,6 +54396,12 @@
         }
       }
     },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -54467,6 +55275,269 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msw": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.3.tgz",
+      "integrity": "sha512-Fqy/TaLKR32x4IkMwudJHJysBzVM/v/lSoMPS9f3QaHLOmb3xHN9YurSUnRt+2eEvNXLjVPij1wMBQtLmTbKsg==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.2",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "cli-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          },
+          "dependencies": {
+            "wrap-ansi": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+              "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              }
+            }
+          }
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "8.2.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+          "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.1.1",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^3.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "0.0.8",
+            "ora": "^5.4.1",
+            "run-async": "^2.4.0",
+            "rxjs": "^7.5.5",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6",
+            "wrap-ansi": "^6.0.1"
+          }
+        },
+        "is-interactive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+          "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+          "dev": true
+        },
+        "is-unicode-supported": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+          "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "ora": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+          "dev": true,
+          "requires": {
+            "bl": "^4.1.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
+    "msw-storybook-addon": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.8.0.tgz",
+      "integrity": "sha512-dw3vZwqjixmiur0vouRSOax7wPSu9Og2Hspy9JZFHf49bZRjwDiLF0Pfn2NXEkGviYJOJiGxS1ejoTiUwoSg4A==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.0.1"
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -55095,6 +56166,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
+    "outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
       "dev": true
     },
     "overlayscrollbars": {
@@ -58635,6 +59712,12 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
+    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -59366,6 +60449,12 @@
           "dev": true
         }
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -61188,6 +62277,31 @@
       "integrity": "sha512-V8X6hPIzY1juvrSVREmtRhK9AHn/8c2z8XxaibESU+jyG/RinZ9x9x6aw8qEuFAi7R6Kl/EWGbU2Yq/9u6TTjw==",
       "dev": true
     },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
+      },
+      "dependencies": {
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        }
+      }
+    },
     "web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
@@ -61597,6 +62711,19 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "wide-align": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,8 @@
     "eslint-plugin-react": "^7.30.0",
     "jest-mock-console": "^1.1.0",
     "jest-watch-typeahead": "^0.6.5",
+    "msw": "^1.2.3",
+    "msw-storybook-addon": "^1.8.0",
     "react-test-renderer": "^17.0.2"
   },
   "scripts": {

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (1.2.3).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import AdminJobsPage from "main/pages/AdminJobsPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
+import AdminReportsPage from "main/pages/AdminReportsPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
@@ -32,6 +33,7 @@ function App() {
             <>
               <Route path="/admin/users" element={<AdminUsersPage />} />
               <Route path="/admin/jobs" element={<AdminJobsPage />} />
+              <Route path="/admin/reports" element={<AdminReportsPage />} />
               <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
               <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
               <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,8 @@ import LeaderboardPage from "main/pages/LeaderboardPage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
+import AdminViewReportPage from "main/pages/AdminViewReportPage";
+
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
 import AdminReportsPage from "main/pages/AdminReportsPage";

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,7 @@ function App() {
               <Route path="/admin/users" element={<AdminUsersPage />} />
               <Route path="/admin/jobs" element={<AdminJobsPage />} />
               <Route path="/admin/reports" element={<AdminReportsPage />} />
+              <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
               <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
               <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
               <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -47,9 +47,10 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/jobs">Manage Jobs</NavDropdown.Item>
-                    <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/reports">Instructor Reports</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Reports/ReportHeaderTable.js
+++ b/frontend/src/main/components/Reports/ReportHeaderTable.js
@@ -4,18 +4,6 @@ import OurTable from "main/components/OurTable";
 export default function ReportHeaderTable({ report  }) {
     const columns = [
         {
-            Header: 'id',
-            accessor: 'id', 
-        },
-        {
-            Header: 'commonsId',
-            accessor: 'commonsId', 
-        },
-        {
-            Header: 'Name',
-            accessor: 'name',
-        },
-        {
             Header: 'Cow Price',
             accessor: 'cowPrice', 
         },
@@ -24,45 +12,35 @@ export default function ReportHeaderTable({ report  }) {
             accessor: 'milkPrice',
         },
         {
-            Header: 'Starting Balance',
+            Header: 'Start Bal',
             accessor: 'startingBalance',
         },
         {
-            Header: 'Starting Date',
-            accessor: 'startingDate',
+            Header: 'Start Date',
+            id: 'startingDate',
+            accessor: (row, _rowIndex) => String(row.startingDate).substring(0, 10)
+
         },
         {
-            Header: 'Show Leaderboard',
+            Header: 'Leaderboard',
             id: 'showLeaderboard',
             accessor: (row, _rowIndex) => String(row.showLeaderboard) // hack needed for boolean values to show up
         },
         {
-            Header: 'Carrying Capacity',
+            Header: 'Capacity',
             accessor: 'carryingCapacity',
         },
         {
-            Header: 'Degradation Rate',
+            Header: 'Degrad. Rate',
             accessor: 'degradationRate',
         },
         {
-            Header: 'BelowCap Strategy',
+            Header: 'BelowCap',
             accessor: 'belowCapacityHealthUpdateStrategy',
         },
         {
-            Header: 'AboveCap Strategy',
+            Header: 'AboveCap',
             accessor: 'aboveCapacityHealthUpdateStrategy',
-        },
-        {
-            Header: 'Num Users',
-            accessor: 'numUsers',
-        },
-        {
-            Header: 'Num Cows',
-            accessor: 'numCows',
-        },
-        {
-            Header: 'Create Date',
-            accessor: 'createDate',
         },
     ];
 

--- a/frontend/src/main/components/Reports/ReportHeaderTable.js
+++ b/frontend/src/main/components/Reports/ReportHeaderTable.js
@@ -31,7 +31,7 @@ export default function ReportHeaderTable({ report  }) {
             accessor: 'carryingCapacity',
         },
         {
-            Header: 'Degrad. Rate',
+            Header: 'Degrad Rate',
             accessor: 'degradationRate',
         },
         {

--- a/frontend/src/main/components/Reports/ReportTable.js
+++ b/frontend/src/main/components/Reports/ReportTable.js
@@ -2,7 +2,7 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useNavigate } from "react-router-dom";
 
 // should take in a players list from a commons
-export default function ReportTable({ reports, storybook = false }) {
+export default function ReportTable({ reports, storybook = false, buttons=true }) {
 
     const testid = "ReportTable";
 
@@ -42,9 +42,11 @@ export default function ReportTable({ reports, storybook = false }) {
             Header: 'Num Cows',
             accessor: 'numCows',
         },
-        ButtonColumn("View Report", "secondary", reportCallback, testid)
     ];
 
+    if (buttons) {
+        columns.push(ButtonColumn("View Report", "secondary", reportCallback, testid));
+    }
     return <OurTable
         data={reports}
         columns={columns}

--- a/frontend/src/main/components/Reports/ReportTable.js
+++ b/frontend/src/main/components/Reports/ReportTable.js
@@ -1,0 +1,54 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
+
+// should take in a players list from a commons
+export default function ReportTable({ reports, storybook = false }) {
+
+    const testid = "ReportTable";
+
+    const navigate = useNavigate();
+
+    const reportCallback = (cell) => {
+        const route = `/admin/report/${cell.row.values["id"]}`
+        if (storybook) {
+            window.alert(`would navigate to ${route}`);
+        } else {
+            navigate(route)
+        }
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id',
+        },
+        {
+            Header: 'commonsId',
+            accessor: 'commonsId',
+        },
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'Create Date',
+            accessor: 'createDate',
+        },
+        {
+            Header: 'Num Users',
+            accessor: 'numUsers',
+        },
+        {
+            Header: 'Num Cows',
+            accessor: 'numCows',
+        },
+        ButtonColumn("View Report", "secondary", reportCallback, testid)
+    ];
+
+    return <OurTable
+        data={reports}
+        columns={columns}
+        testid={testid}
+    />;
+
+};

--- a/frontend/src/main/pages/AdminReportsPage.js
+++ b/frontend/src/main/pages/AdminReportsPage.js
@@ -5,7 +5,6 @@ import ReportTable  from 'main/components/Reports/ReportTable';
 
 export default function AdminReportsPage()
 {
-  // const { data: currentUser } = useCurrentUser();
 
   // Stryker disable  all 
   const { data: reports, error: _error, status: _status } =

--- a/frontend/src/main/pages/AdminReportsPage.js
+++ b/frontend/src/main/pages/AdminReportsPage.js
@@ -1,0 +1,28 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+// import CommonsTable from 'main/components/Commons/CommonsTable';
+// import { useBackend } from 'main/utils/useBackend';
+// import { useCurrentUser } from "main/utils/currentUser";
+
+export default function AdminReportsPage()
+{
+  // const { data: currentUser } = useCurrentUser();
+
+  // Stryker disable  all 
+  // const { data: commons, error: _error, status: _status } =
+  //   useBackend(
+  //     ["/api/reports/all"],
+  //     { method: "GET", url: "/api/reports/all" },
+  //     []
+  //   );
+  // Stryker restore  all 
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Instructor Reports</h1>
+        {/* <CommonsTable commons={commons} currentUser={currentUser} /> */}
+      </div>
+    </BasicLayout>
+  )
+};

--- a/frontend/src/main/pages/AdminReportsPage.js
+++ b/frontend/src/main/pages/AdminReportsPage.js
@@ -2,7 +2,6 @@ import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useBackend } from 'main/utils/useBackend';
 import ReportTable  from 'main/components/Reports/ReportTable';
-// import { useCurrentUser } from "main/utils/currentUser";
 
 export default function AdminReportsPage()
 {

--- a/frontend/src/main/pages/AdminReportsPage.js
+++ b/frontend/src/main/pages/AdminReportsPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import CommonsTable from 'main/components/Commons/CommonsTable';
-// import { useBackend } from 'main/utils/useBackend';
+import { useBackend } from 'main/utils/useBackend';
+import ReportTable  from 'main/components/Reports/ReportTable';
 // import { useCurrentUser } from "main/utils/currentUser";
 
 export default function AdminReportsPage()
@@ -9,19 +9,19 @@ export default function AdminReportsPage()
   // const { data: currentUser } = useCurrentUser();
 
   // Stryker disable  all 
-  // const { data: commons, error: _error, status: _status } =
-  //   useBackend(
-  //     ["/api/reports/all"],
-  //     { method: "GET", url: "/api/reports/all" },
-  //     []
-  //   );
-  // Stryker restore  all 
+  const { data: reports, error: _error, status: _status } =
+    useBackend(
+      ["/api/reports"],
+      { method: "GET", url: "/api/reports" },
+      []
+    );
+  // Stryker restore all 
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Instructor Reports</h1>
-        {/* <CommonsTable commons={commons} currentUser={currentUser} /> */}
+        <ReportTable reports={reports} /> 
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/AdminViewReportPage.js
+++ b/frontend/src/main/pages/AdminViewReportPage.js
@@ -1,31 +1,48 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
-// import CommonsTable from 'main/components/Commons/CommonsTable';
-// import { useBackend } from 'main/utils/useBackend';
-// import { useCurrentUser } from "main/utils/currentUser";
+import ReportTable from "main/components/Reports/ReportTable";
+import ReportHeaderTable from "main/components/Reports/ReportHeaderTable";
+import ReportLineTable from "main/components/Reports/ReportLineTable";
+import { useBackend } from 'main/utils/useBackend';
+import { Button } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
 
-export default function AdminViewReportPage()
-{
+export default function AdminViewReportPage() {
   const { reportId } = useParams();
-
-  // const { data: currentUser } = useCurrentUser();
+  const navigate = useNavigate();
 
   // Stryker disable  all 
-  // const { data: commons, error: _error, status: _status } =
-  //   useBackend(
-  //     ["/api/reports/all"],
-  //     { method: "GET", url: "/api/reports/all" },
-  //     []
-  //   );
+  const { data: reportHeader} =
+    useBackend(
+      ["/api/reports/byReportId"],
+      {
+        method: "GET", url: "/api/reports/byReportId",
+        params: { reportId: reportId },
+      },
+      []
+    );
+
+  const { data: reportLines} =
+    useBackend(
+      ["/api/reports/lines"],
+      {
+        method: "GET", url: "/api/reports/lines",
+        params: { reportId: reportId },
+      },
+      []
+    );
   // Stryker restore  all 
 
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Instructor Report </h1>
-        <p>The reportId is: {reportId}</p>
-        {/* <CommonsTable commons={commons} currentUser={currentUser} /> */}
+        <Button style={{float: "right"}} variant="primary" onClick={() => navigate("/admin/reports")} >Back to Reports</Button>
+        <h1>Instructor Report</h1>
+        <ReportTable reports={[reportHeader]} buttons={false}  /> 
+        <ReportHeaderTable report={reportHeader}  /> 
+        <h2>Farmers</h2>
+        <ReportLineTable reportLines={reportLines}  /> 
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/AdminViewReportPage.js
+++ b/frontend/src/main/pages/AdminViewReportPage.js
@@ -1,0 +1,32 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+// import CommonsTable from 'main/components/Commons/CommonsTable';
+// import { useBackend } from 'main/utils/useBackend';
+// import { useCurrentUser } from "main/utils/currentUser";
+
+export default function AdminViewReportPage()
+{
+  const { reportId } = useParams();
+
+  // const { data: currentUser } = useCurrentUser();
+
+  // Stryker disable  all 
+  // const { data: commons, error: _error, status: _status } =
+  //   useBackend(
+  //     ["/api/reports/all"],
+  //     { method: "GET", url: "/api/reports/all" },
+  //     []
+  //   );
+  // Stryker restore  all 
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Instructor Report </h1>
+        <p>The reportId is: {reportId}</p>
+        {/* <CommonsTable commons={commons} currentUser={currentUser} /> */}
+      </div>
+    </BasicLayout>
+  )
+};

--- a/frontend/src/stories/components/Reports/ReportTable.stories.js
+++ b/frontend/src/stories/components/Reports/ReportTable.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import ReportTable from "main/components/Reports/ReportTable";
+import reportFixtures from 'fixtures/reportFixtures';
+
+export default {
+    title: 'components/Reports/ReportTable',
+    component: ReportTable
+};
+
+const Template = (args) => {
+    return (
+        <ReportTable storybook={true} {...args} />
+    )
+};
+
+export const ThreeReports = Template.bind({});
+
+ThreeReports.args = {
+    reports: reportFixtures.threeReports
+};

--- a/frontend/src/stories/pages/AdminReportsPage.stories.js
+++ b/frontend/src/stories/pages/AdminReportsPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import AdminReportsPage from "main/pages/AdminReportsPage";
+
+export default {
+    title: 'pages/AdminReportsPage',
+    component: AdminReportsPage
+};
+
+const Template = () => <AdminReportsPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/AdminViewReportPage.stories.js
+++ b/frontend/src/stories/pages/AdminViewReportPage.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import AdminViewReportPage from "main/pages/AdminViewReportPage";
-import { Route, Routes } from 'react-router-dom';
 
 export default {
     title: 'pages/AdminViewReportPage',
@@ -9,11 +8,6 @@ export default {
 
 export const Default = () => {
     return (
-        <Routes>
-            <Route
-                element={<AdminViewReportPage  />}
-                path="/admin/report/:reportId" 
-            />
-        </Routes>
+       <AdminViewReportPage  />
     )
 }

--- a/frontend/src/stories/pages/AdminViewReportPage.stories.js
+++ b/frontend/src/stories/pages/AdminViewReportPage.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import AdminViewReportPage from "main/pages/AdminViewReportPage";
+import { Route, Routes } from 'react-router-dom';
+
+export default {
+    title: 'pages/AdminViewReportPage',
+    component: AdminViewReportPage,
+};
+
+export const Default = () => {
+    return (
+        <Routes>
+            <Route
+                element={<AdminViewReportPage  />}
+                path="/admin/report/:reportId" 
+            />
+        </Routes>
+    )
+}

--- a/frontend/src/stories/pages/LeaderboardPage.stories.js
+++ b/frontend/src/stories/pages/LeaderboardPage.stories.js
@@ -6,6 +6,7 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { rest } from 'msw';
 import userCommonsFixtures from 'fixtures/userCommonsFixtures';
+import commonsFixtures from 'fixtures/commonsFixtures';
 
 export default {
     title: 'pages/LeaderboardPage',
@@ -13,14 +14,7 @@ export default {
 };
 
 export const OrdinaryUser = () => {
-    return (
-        <Routes>
-            <Route
-                element={<LeaderboardPage />}
-                path="/leaderboard/:commonsId"
-            />
-        </Routes>
-    )
+    return (<LeaderboardPage />)
 }
 
 OrdinaryUser.parameters = {
@@ -31,7 +25,10 @@ OrdinaryUser.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/usercommons/commons/all?commonsId=17', (_req, res, ctx) => {
+        rest.get('/api/commons', (_req, res, ctx) => {
+            return res(ctx.json(commonsFixtures.threeCommons[0]));
+        }),
+        rest.get('/api/usercommons/commons/all', (_req, res, ctx) => {
             return res(ctx.json(userCommonsFixtures.tenUserCommons));
         }),
     ]
@@ -39,12 +36,7 @@ OrdinaryUser.parameters = {
 
 export const AdminUser = () => {
     return (
-        <Routes>
-            <Route
-                element={<LeaderboardPage />}
-                path="/leaderboard/:commonsId"
-            />
-        </Routes>
+       <LeaderboardPage />
     )
 }
 
@@ -56,8 +48,11 @@ AdminUser.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/usercommons/commons/all?commonsId=17', (_req, res, ctx) => {
+        rest.get('/api/usercommons/commons/all', (_req, res, ctx) => {
             return res(ctx.json(userCommonsFixtures.tenUserCommons));
+        }),
+        rest.get('/api/commons', (_req, res, ctx) => {
+            return res(ctx.json(commonsFixtures.threeCommons[0]));
         }),
     ]
 }

--- a/frontend/src/stories/pages/LeaderboardPage.stories.js
+++ b/frontend/src/stories/pages/LeaderboardPage.stories.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import LeaderboardPage from "main/pages/LeaderboardPage";
+import { Route, Routes } from 'react-router-dom';
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from 'msw';
+import userCommonsFixtures from 'fixtures/userCommonsFixtures';
+
+export default {
+    title: 'pages/LeaderboardPage',
+    component: LeaderboardPage,
+};
+
+export const OrdinaryUser = () => {
+    return (
+        <Routes>
+            <Route
+                element={<LeaderboardPage />}
+                path="/leaderboard/:commonsId"
+            />
+        </Routes>
+    )
+}
+
+OrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/usercommons/commons/all?commonsId=17', (_req, res, ctx) => {
+            return res(ctx.json(userCommonsFixtures.tenUserCommons));
+        }),
+    ]
+}
+
+export const AdminUser = () => {
+    return (
+        <Routes>
+            <Route
+                element={<LeaderboardPage />}
+                path="/leaderboard/:commonsId"
+            />
+        </Routes>
+    )
+}
+
+AdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/usercommons/commons/all?commonsId=17', (_req, res, ctx) => {
+            return res(ctx.json(userCommonsFixtures.tenUserCommons));
+        }),
+    ]
+}

--- a/frontend/src/stories/pages/LeaderboardPage.stories.js
+++ b/frontend/src/stories/pages/LeaderboardPage.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import LeaderboardPage from "main/pages/LeaderboardPage";
-import { Route, Routes } from 'react-router-dom';
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -13,11 +12,11 @@ export default {
     component: LeaderboardPage,
 };
 
-export const OrdinaryUser = () => {
+export const OrdinaryUserShowLeaderboardTrue = () => {
     return (<LeaderboardPage />)
 }
 
-OrdinaryUser.parameters = {
+OrdinaryUserShowLeaderboardTrue.parameters = {
     msw: [
         rest.get('/api/currentUser', (_req, res, ctx) => {
             return res(ctx.json(apiCurrentUserFixtures.userOnly));
@@ -27,6 +26,27 @@ OrdinaryUser.parameters = {
         }),
         rest.get('/api/commons', (_req, res, ctx) => {
             return res(ctx.json(commonsFixtures.threeCommons[0]));
+        }),
+        rest.get('/api/usercommons/commons/all', (_req, res, ctx) => {
+            return res(ctx.json(userCommonsFixtures.tenUserCommons));
+        }),
+    ]
+}
+
+export const OrdinaryUserShowLeaderboardFalse = () => {
+    return (<LeaderboardPage />)
+}
+
+OrdinaryUserShowLeaderboardFalse.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/commons', (_req, res, ctx) => {
+            return res(ctx.json({...commonsFixtures.threeCommons[0], showLeaderboard: false}));
         }),
         rest.get('/api/usercommons/commons/all', (_req, res, ctx) => {
             return res(ctx.json(userCommonsFixtures.tenUserCommons));

--- a/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
@@ -37,7 +37,7 @@ describe("ReportHeaderTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowPrice`)).toHaveTextContent("100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-milkPrice`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-startingBalance`)).toHaveTextContent("10000");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingDate`)).toHaveTextContent("2023-08-06");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingDate`)).toHaveTextContent(/^2023-08-06$/);
     expect(screen.getByTestId(`${testId}-cell-row-0-col-showLeaderboard`)).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-carryingCapacity`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-degradationRate`)).toHaveTextContent("0.1");

--- a/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
@@ -20,7 +20,7 @@ describe("ReportHeaderTable tests", () => {
     );
 
     const expectedFields = [ 'cowPrice', 'milkPrice', 'startingBalance', 'startingDate', 'showLeaderboard', 'carryingCapacity', 'degradationRate', 'belowCapacityHealthUpdateStrategy', 'aboveCapacityHealthUpdateStrategy']
-    const expectedHeaders = ['Cow Price', 'Milk Price', 'Starting Balance', 'Starting Date', 'Show Leaderboard', 'Carrying Capacity', 'Degradation Rate', 'BelowCap Strategy', 'AboveCap Strategy']
+    const expectedHeaders = ['Cow Price', 'Milk Price', 'Start Bal', 'Start Date', 'Leaderboard', 'Capacity', 'Degrad Rate', 'BelowCap', 'AboveCap']
 
     const testId = "ReportHeaderTable"
 
@@ -37,7 +37,7 @@ describe("ReportHeaderTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowPrice`)).toHaveTextContent("100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-milkPrice`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-startingBalance`)).toHaveTextContent("10000");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingDate`)).toHaveTextContent("2023-08-06T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingDate`)).toHaveTextContent("2023-08-06");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-showLeaderboard`)).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-carryingCapacity`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-degradationRate`)).toHaveTextContent("0.1");

--- a/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
@@ -19,8 +19,8 @@ describe("ReportHeaderTable tests", () => {
 
     );
 
-    const expectedFields = ['id', 'commonsId', 'name', 'cowPrice', 'milkPrice', 'startingBalance', 'startingDate', 'showLeaderboard', 'carryingCapacity', 'degradationRate', 'belowCapacityHealthUpdateStrategy', 'aboveCapacityHealthUpdateStrategy', 'numUsers', 'numCows', 'createDate']
-    const expectedHeaders = ['id', 'commonsId', 'Name', 'Cow Price', 'Milk Price', 'Starting Balance', 'Starting Date', 'Show Leaderboard', 'Carrying Capacity', 'Degradation Rate', 'BelowCap Strategy', 'AboveCap Strategy', 'Num Users', 'Num Cows', 'Create Date']
+    const expectedFields = [ 'cowPrice', 'milkPrice', 'startingBalance', 'startingDate', 'showLeaderboard', 'carryingCapacity', 'degradationRate', 'belowCapacityHealthUpdateStrategy', 'aboveCapacityHealthUpdateStrategy']
+    const expectedHeaders = ['Cow Price', 'Milk Price', 'Starting Balance', 'Starting Date', 'Show Leaderboard', 'Carrying Capacity', 'Degradation Rate', 'BelowCap Strategy', 'AboveCap Strategy']
 
     const testId = "ReportHeaderTable"
 
@@ -34,9 +34,6 @@ describe("ReportHeaderTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("3");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-commonsId`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Blue");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowPrice`)).toHaveTextContent("100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-milkPrice`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-startingBalance`)).toHaveTextContent("10000");
@@ -46,10 +43,7 @@ describe("ReportHeaderTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-degradationRate`)).toHaveTextContent("0.1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-belowCapacityHealthUpdateStrategy`)).toHaveTextContent("Constant");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-aboveCapacityHealthUpdateStrategy`)).toHaveTextContent("Linear");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-numUsers`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-numCows`)).toHaveTextContent("3");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-createDate`)).toHaveTextContent("2023-08-07T01:12:09.088+00:00");
-
+   
   });
 
 });

--- a/frontend/src/tests/components/Reports/ReportTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportTable.test.js
@@ -1,28 +1,43 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import ReportTable from "main/components/Reports/ReportTable";
 import reportFixtures from "fixtures/reportFixtures";
 
 
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({
+    commonsId: 1
+  }),
+  useNavigate: () => mockNavigate
+}));
+
 describe("ReportTable tests", () => {
+
+  const testId = "ReportTable"
+
   const queryClient = new QueryClient();
 
   test("Has the expected column headers and content", () => {
 
+    // act
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <ReportTable reports={reportFixtures.threeReports}  />
+          <ReportTable reports={reportFixtures.threeReports} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
-    const expectedFields = ['id', 'commonsId', 'name',   'numUsers', 'numCows', 'createDate']
-    const expectedHeaders = ['id', 'commonsId', 'Name',  'Num Users', 'Num Cows', 'Create Date']
+    // assert 
 
-    const testId = "ReportTable"
+    const expectedFields = ['id', 'commonsId', 'name', 'numUsers', 'numCows', 'createDate']
+    const expectedHeaders = ['id', 'commonsId', 'Name', 'Num Users', 'Num Cows', 'Create Date']
+
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -40,6 +55,55 @@ describe("ReportTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-numUsers`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-numCows`)).toHaveTextContent("3");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-createDate`)).toHaveTextContent("2023-08-07T01:12:09.088+00:00");
+
+  });
+
+  test("When not on storybook, navigates to view page", () => {
+
+    // act 
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportTable reports={reportFixtures.threeReports} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert 
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`)).toBeInTheDocument();
+    const viewButton = screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`);
+    viewButton.click();
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/report/1");
+
+  });
+
+  test("When on storybook, calls window.alert", async () => {
+
+    // arrange
+
+    const mockAlert = jest.spyOn(window, "alert").mockImplementation(() => { });
+
+    // act 
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportTable reports={reportFixtures.threeReports} storybook={true} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert 
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`)).toBeInTheDocument();
+    const viewButton = screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`);
+    viewButton.click();
+    await waitFor(()=>{
+      expect(mockAlert).toHaveBeenCalledWith(`would navigate to /admin/report/1`);
+    });
+    mockAlert.mockRestore();
 
   });
 

--- a/frontend/src/tests/components/Reports/ReportTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportTable.test.js
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import ReportTable from "main/components/Reports/ReportTable";
+import reportFixtures from "fixtures/reportFixtures";
+
+
+describe("ReportTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportTable reports={reportFixtures.threeReports}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedFields = ['id', 'commonsId', 'name',   'numUsers', 'numCows', 'createDate']
+    const expectedHeaders = ['id', 'commonsId', 'Name',  'Num Users', 'Num Cows', 'Create Date']
+
+    const testId = "ReportTable"
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commonsId`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Blue");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-numUsers`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-numCows`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-createDate`)).toHaveTextContent("2023-08-07T01:12:09.088+00:00");
+
+  });
+
+});
+

--- a/frontend/src/tests/components/Reports/ReportTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportTable.test.js
@@ -74,6 +74,7 @@ describe("ReportTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`)).toBeInTheDocument();
     const viewButton = screen.getByTestId(`${testId}-cell-row-0-col-View Report-button`);
+    expect(viewButton).toHaveClass("btn-secondary");
     viewButton.click();
     expect(mockNavigate).toHaveBeenCalledWith("/admin/report/1");
 

--- a/frontend/src/tests/pages/AdminReportsPage.test.js
+++ b/frontend/src/tests/pages/AdminReportsPage.test.js
@@ -1,5 +1,4 @@
 import {  render, screen } from "@testing-library/react";
-// import mockConsole from "jest-mock-console";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";

--- a/frontend/src/tests/pages/AdminReportsPage.test.js
+++ b/frontend/src/tests/pages/AdminReportsPage.test.js
@@ -6,7 +6,6 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import AdminReportsPage from "main/pages/AdminReportsPage";
-// import reportLineFixtures from "fixtures/reportLineFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 

--- a/frontend/src/tests/pages/AdminReportsPage.test.js
+++ b/frontend/src/tests/pages/AdminReportsPage.test.js
@@ -1,0 +1,55 @@
+import {  render, screen } from "@testing-library/react";
+// import mockConsole from "jest-mock-console";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminReportsPage from "main/pages/AdminReportsPage";
+// import reportLineFixtures from "fixtures/reportLineFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("AdminReportsPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "CommonsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders correctly for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminReportsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByText("Instructor Reports")).toBeInTheDocument();
+    });
+
+   
+});

--- a/frontend/src/tests/pages/AdminReportsPage.test.js
+++ b/frontend/src/tests/pages/AdminReportsPage.test.js
@@ -19,16 +19,7 @@ jest.mock('react-router-dom', () => ({
 
 describe("AdminReportsPage tests", () => {
     const axiosMock = new AxiosMockAdapter(axios);
-
-    const testId = "CommonsTable";
-
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
-
+    
     const setupAdminUser = () => {
         axiosMock.reset();
         axiosMock.resetHistory();

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -1,0 +1,90 @@
+import {  fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminViewReportPage from "main/pages/AdminViewReportPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import reportFixtures from "fixtures/reportFixtures";
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("AdminViewReportPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders correctly for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/reports/byReportId").reply(200, reportFixtures.threeReports[0]);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminViewReportPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+
+        waitFor( () => {
+           expect(axiosMock.history.get.length).toBe(3);
+        })
+
+        expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
+        expect(axiosMock.history.get[1].url).toBe("/api/systemInfo");
+        expect(axiosMock.history.get[2].url).toBe("/api/reports/byReportId");
+
+        expect(screen.getByText("Instructor Report")).toBeInTheDocument();
+        expect(screen.getByText("Back to Reports")).toBeInTheDocument();
+        expect(screen.getByText("Back to Reports")).toBeInTheDocument();
+        const backButton = screen.getByText("Back to Reports");
+        expect(backButton).toHaveAttribute("style", "float: right;");
+       
+        expect(screen.getByText("Cow Price")).toBeInTheDocument();
+        expect(screen.getByText("Num Users")).toBeInTheDocument();
+
+        expect(screen.getByTestId("ReportTable-cell-row-0-col-numUsers")).toBeInTheDocument();
+
+    });
+
+    test("back to reports button navigates correctly", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/reports/byReportId").reply(200, reportFixtures.threeReports[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminViewReportPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByText("Back to Reports")).toBeInTheDocument();
+        const backButton = screen.getByText("Back to Reports");
+        fireEvent.click(backButton);
+
+        expect(screen.queryByText("View Report")).not.toBeInTheDocument();
+        
+        expect(mockedNavigate).toHaveBeenCalledTimes(1);
+        expect(mockedNavigate).toHaveBeenCalledWith("/admin/reports");
+    });
+
+   
+});

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -42,8 +42,8 @@ describe("AdminViewReportPage tests", () => {
 
         // assert
 
-        waitFor( () => {
-           expect(axiosMock.history.get.length).toBe(3);
+        await waitFor( () => {
+            expect(axiosMock.history.get.length).toBe(3);
         })
 
         expect(axiosMock.history.get[0].url).toBe("/api/currentUser");

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -8,6 +8,8 @@ import AdminViewReportPage from "main/pages/AdminViewReportPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import reportFixtures from "fixtures/reportFixtures";
+import reportLineFixtures from "fixtures/reportLineFixtures";
+
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -30,6 +32,7 @@ describe("AdminViewReportPage tests", () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/reports/byReportId").reply(200, reportFixtures.threeReports[0]);
+        axiosMock.onGet("/api/reports/lines").reply(200, reportLineFixtures.twoReportLines);
 
         // act
         render(
@@ -43,12 +46,13 @@ describe("AdminViewReportPage tests", () => {
         // assert
 
         await waitFor( () => {
-            expect(axiosMock.history.get.length).toBe(3);
+            expect(axiosMock.history.get.length).toBe(4);
         })
 
         expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
         expect(axiosMock.history.get[1].url).toBe("/api/systemInfo");
         expect(axiosMock.history.get[2].url).toBe("/api/reports/byReportId");
+        expect(axiosMock.history.get[3].url).toBe("/api/reports/lines");
 
         expect(screen.getByText("Instructor Report")).toBeInTheDocument();
         expect(screen.getByText("Back to Reports")).toBeInTheDocument();

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
@@ -14,7 +14,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.domain.Sort.Order;
+
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +44,19 @@ public class ReportsController extends ApiController {
     @Autowired
     ReportLineRepository reportLineRepository;
 
+
+    @Operation(summary = "Get report headers for a given user commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("")
+    public Iterable<Report> allReports() {   
+        Iterable<Report> reports = reportRepository.findAll(
+            Sort.by(List.of(
+                new Order(Sort.Direction.DESC, "StartTime"),
+                new Order(Sort.Direction.ASC, "ProgDate")
+              ))
+        );
+        return reports;
+    }
 
     @Operation(summary = "Get report headers for a given user commons")
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort.Order;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -45,16 +46,26 @@ public class ReportsController extends ApiController {
     ReportLineRepository reportLineRepository;
 
 
-    @Operation(summary = "Get report headers for a given user commons")
+    @Operation(summary = "Get all report headers")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public Iterable<Report> allReports() {   
         Iterable<Report> reports = reportRepository.findAll(
             Sort.by(List.of(
-                new Order(Sort.Direction.DESC, "StartTime"),
-                new Order(Sort.Direction.ASC, "ProgDate")
+                new Order(Sort.Direction.ASC, "commonsId"),
+                new Order(Sort.Direction.DESC, "id")
               ))
         );
+        return reports;
+    }
+
+    @Operation(summary = "Get report headers for a given report")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/byReportId")
+    public Optional<Report> findByReportId(
+            @Parameter(name="reportId") @RequestParam Long reportId
+    ) {   
+        Optional<Report> reports = reportRepository.findById(reportId);
         return reports;
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ReportRepository.java
@@ -4,7 +4,10 @@ import edu.ucsb.cs156.happiercows.entities.Report;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Sort;
+
 @Repository
 public interface ReportRepository extends CrudRepository<Report, Long> {
     Iterable<Report> findAllByCommonsId(Long commonsId);
+    Iterable<Report> findAll(Sort sort);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
@@ -121,12 +121,29 @@ public class ReportsControllerTests extends ControllerTestCase {
                         .cowDeaths(6)
                         .build();
 
+
+ @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void get_all_report_headers() throws Exception {
+                List<Report> reports = List.of(expectedReportHeader);
+                when(reportRepository.findAll(any())).thenReturn(reports);
+               
+                MvcResult response = mockMvc.perform(get("/api/reports")).andDo(print())
+                                .andExpect(status().isOk()).andReturn();
+
+                verify(reportRepository, times(1)).findAll(any());
+
+                String responseString = response.getResponse().getContentAsString();
+                List<Report> actualReports = objectMapper.readValue(responseString, new TypeReference<List<Report>>() {
+                });
+                assertEquals(reports, actualReports);
+        }
+                        
         @WithMockUser(roles = { "ADMIN" })
         @Test
         public void get_reports_headers_commonId() throws Exception {
                 List<Report> reports = List.of(expectedReportHeader);
                 when(reportRepository.findAllByCommonsId(17L)).thenReturn(reports);
-                // when(reportLineRepository.findAllByReportId(432L)).thenReturn(List.of(expectedReportLine));
                
                 MvcResult response = mockMvc.perform(get("/api/reports/headers?commonsId=17")).andDo(print())
                                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
@@ -122,7 +122,7 @@ public class ReportsControllerTests extends ControllerTestCase {
                         .build();
 
 
- @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN" })
         @Test
         public void get_all_report_headers() throws Exception {
                 List<Report> reports = List.of(expectedReportHeader);
@@ -137,6 +137,23 @@ public class ReportsControllerTests extends ControllerTestCase {
                 List<Report> actualReports = objectMapper.readValue(responseString, new TypeReference<List<Report>>() {
                 });
                 assertEquals(reports, actualReports);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void get_specific_report_header() throws Exception {
+                Optional<Report> optionalReport = Optional.of(expectedReportHeader);
+                when(reportRepository.findById(eq(432L))).thenReturn(optionalReport);
+               
+                MvcResult response = mockMvc.perform(get("/api/reports/byReportId?reportId=432")).andDo(print())
+                                .andExpect(status().isOk()).andReturn();
+
+                verify(reportRepository, times(1)).findById(eq(432L));
+
+                String responseString = response.getResponse().getContentAsString();
+                Optional<Report> actualReports = objectMapper.readValue(responseString, new TypeReference<Optional<Report>>() {
+                });
+                assertEquals(optionalReport, actualReports);
         }
                         
         @WithMockUser(roles = { "ADMIN" })


### PR DESCRIPTION
# Overview

In this PR, we create a reports page where the Admin can view reports created by the InstructorReport job.

# Merge these PRs first

* #58 (report jobs) 
* #59 (report controllers)
* #60 (springfox -> springdoc)
* #61 (report components)

# Issues Addressed

Closes #18 

# Link to Storybook

TODO link to storybook

# Details

This PR finishes work on the first draft of creating instructor reports. 

- [x] There is a backend endpoint where the instructor can request all reports.
- [x] The instructor can request an instructor report on the jobs page, for all commons, or a specific commons
- [x] There is a job that *could* be scheduled (though it may not be scheduled yet) to run these reports periodically (e.g. once a day, twice a day, etc.)
- [x] The instructor can view all reports that have been generated on the Admin / Reports page at `/admin/reports`
- [x] There is a link on the Navbar Admin dropdown for Reports that takes the user to `/admin/reports`
- [x] The instructor can select a report and view the report detail at `/admin/reports/:report_id`; that page uses the `ReportHeaderTable` and `ReportDetailTable` to show the results.

# Test Plan (for interactive testing)

1.  Create a user commons or two.  Have a low capacity so that health will go down with relatively few cows.
2. Have at least two users join one of the user commons
3. Generate a report
4. Have users buy some cows (enough to be over capacity), and run the Milk The Cows and or Cow Health update jobs a few times, alternating with generating reports.
5. View the reports page and see if the reports reflect the changes over time.

