### PR TITLE
Pc report csv

### DIFF
--- a/frontend/src/main/pages/AdminViewReportPage.js
+++ b/frontend/src/main/pages/AdminViewReportPage.js
@@ -5,7 +5,7 @@ import ReportTable from "main/components/Reports/ReportTable";
 import ReportHeaderTable from "main/components/Reports/ReportHeaderTable";
 import ReportLineTable from "main/components/Reports/ReportLineTable";
 import { useBackend } from 'main/utils/useBackend';
-import { Button } from "react-bootstrap";
+import { Button, Row, Col } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 
 export default function AdminViewReportPage() {
@@ -13,7 +13,7 @@ export default function AdminViewReportPage() {
   const navigate = useNavigate();
 
   // Stryker disable  all 
-  const { data: reportHeader} =
+  const { data: reportHeader } =
     useBackend(
       ["/api/reports/byReportId"],
       {
@@ -23,7 +23,7 @@ export default function AdminViewReportPage() {
       []
     );
 
-  const { data: reportLines} =
+  const { data: reportLines } =
     useBackend(
       ["/api/reports/lines"],
       {
@@ -37,12 +37,25 @@ export default function AdminViewReportPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <Button style={{float: "right"}} variant="primary" onClick={() => navigate("/admin/reports")} >Back to Reports</Button>
-        <h1>Instructor Report</h1>
-        <ReportTable reports={[reportHeader]} buttons={false}  /> 
-        <ReportHeaderTable report={reportHeader}  /> 
-        <h2>Farmers</h2>
-        <ReportLineTable reportLines={reportLines}  /> 
+        <Row>
+          <Col>
+            <h1>Instructor Report</h1>
+          </Col>
+          <Col>
+            <Button variant="primary" onClick={() => navigate("/admin/reports")} >Back to Reports</Button>
+          </Col>
+        </Row>
+        <ReportTable reports={[reportHeader]} buttons={false} />
+        <ReportHeaderTable report={reportHeader} />
+        <Row  className="pt-5">
+          <Col>
+            <h2>Farmers</h2>
+          </Col>
+          <Col>
+            <Button variant="secondary" href={`/api/reports/download?reportId=${reportId}`} >Download as CSV</Button>
+          </Col>
+        </Row>
+        <ReportLineTable reportLines={reportLines} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -59,8 +59,6 @@ describe("AdminViewReportPage tests", () => {
 
         expect(screen.getByText("Instructor Report")).toBeInTheDocument();
         expect(screen.getByText("Back to Reports")).toBeInTheDocument();
-        expect(screen.getByText("Back to Reports")).toBeInTheDocument();
-        const backButton = screen.getByText("Back to Reports");
        
         expect(screen.getByText("Cow Price")).toBeInTheDocument();
         expect(screen.getByText("Num Users")).toBeInTheDocument();

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -43,18 +43,18 @@ describe("AdminViewReportPage tests", () => {
         // assert
 
         await waitFor( () => {
-            expect(axiosMock.history.get.length).toBe(3);
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(4);
         })
 
         expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
         expect(axiosMock.history.get[1].url).toBe("/api/systemInfo");
         expect(axiosMock.history.get[2].url).toBe("/api/reports/byReportId");
+        expect(axiosMock.history.get[3].url).toBe("/api/reports/lines");
 
         expect(screen.getByText("Instructor Report")).toBeInTheDocument();
         expect(screen.getByText("Back to Reports")).toBeInTheDocument();
         expect(screen.getByText("Back to Reports")).toBeInTheDocument();
         const backButton = screen.getByText("Back to Reports");
-        expect(backButton).toHaveAttribute("style", "float: right;");
        
         expect(screen.getByText("Cow Price")).toBeInTheDocument();
         expect(screen.getByText("Num Users")).toBeInTheDocument();

--- a/frontend/src/tests/pages/AdminViewReportPage.test.js
+++ b/frontend/src/tests/pages/AdminViewReportPage.test.js
@@ -14,7 +14,10 @@ const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockedNavigate
+    useNavigate: () => mockedNavigate,
+    useParams: () => ({
+        reportId: 17
+    }),
 }));
 
 describe("AdminViewReportPage tests", () => {
@@ -87,6 +90,24 @@ describe("AdminViewReportPage tests", () => {
         
         expect(mockedNavigate).toHaveBeenCalledTimes(1);
         expect(mockedNavigate).toHaveBeenCalledWith("/admin/reports");
+    });
+
+    test("CSV button has correct address", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/reports/byReportId").reply(200, reportFixtures.threeReports[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminViewReportPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByText("Download as CSV")).toBeInTheDocument();
+        const csvButton = screen.getByText("Download as CSV");
+        expect(csvButton).toHaveAttribute("href", "/api/reports/download?reportId=17");
     });
 
    

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
     <parent>
@@ -34,7 +36,8 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-mongodb -->
+        <!--
+        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-mongodb -->
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -83,22 +86,24 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.7.0</version>
-         </dependency>
-      
+        </dependency>
+
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
 
-        <!-- To help with testing async jobs; see http://www.awaitility.org/ https://stackoverflow.com/a/46227996 -->
+        <!-- To help with testing async jobs; see http://www.awaitility.org/
+        https://stackoverflow.com/a/46227996 -->
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
         </dependency>
 
-        <!-- to manage security context in async threads; see: https://www.baeldung.com/spring-security-async-principal-propagation -->
+        <!-- to manage security context in async threads; see:
+        https://www.baeldung.com/spring-security-async-principal-propagation -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
@@ -222,6 +227,9 @@
                         <param>edu.ucsb.cs156.happiercows.config.SpringFoxConfig</param>
                     </excludedClasses>
                     <excludedTestClasses></excludedTestClasses>
+                    <excludedMethods>
+                        <param>edu.ucsb.cs156.happiercows.helpers.ReportCSVHelper.flush_and_close_noPitest</param>
+                    </excludedMethods>
                     <outputFormats>
                         <outputFormat>HTML</outputFormat>
                         <outputFormat>CSV</outputFormat>
@@ -233,7 +241,8 @@
                         <avoidCallsTo>org.slf4j</avoidCallsTo>
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                         <avoidCallsTo>java.lang.Exception</avoidCallsTo>
-                        <avoidCallsTo>import org.springframework.security.core.context.SecurityContextHolder</avoidCallsTo>
+                        <avoidCallsTo>import
+                            org.springframework.security.core.context.SecurityContextHolder</avoidCallsTo>
                     </avoidCallsTo>
                     <timestampedReports>false</timestampedReports>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
 
+        <!-- https://central.sonatype.com/artifact/org.apache.commons/commons-csv/1.10.0 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                     </excludedClasses>
                     <excludedTestClasses></excludedTestClasses>
                     <excludedMethods>
-                        <param>edu.ucsb.cs156.happiercows.helpers.ReportCSVHelper.flush_and_close_noPitest</param>
+                        <param>flush_and_close_noPitest</param>
                     </excludedMethods>
                     <outputFormats>
                         <outputFormat>HTML</outputFormat>

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -95,7 +96,7 @@ public class ReportsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/download")
     public ResponseEntity<Resource> getLinesCSV(
-            @Parameter(name = "reportId") @RequestParam Long reportId) {
+            @Parameter(name = "reportId") @RequestParam Long reportId) throws IOException {
 
         Iterable<ReportLine> reportLines = reportLineRepository.findAllByReportId(reportId);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
@@ -19,8 +19,9 @@ import lombok.NoArgsConstructor;
  * with an instructor report.
  */
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // prevents jacoco from reporting missed coverage
 public class ReportCSVHelper {
+
+  private ReportCSVHelper() {}
 
   /**
    * This method is a hack to avoid a jacoco issue; it isn't possible to 
@@ -36,7 +37,6 @@ public class ReportCSVHelper {
     out.close();
   }
   
-
   public static ByteArrayInputStream toCSV(Iterable<ReportLine> lines) throws IOException {
     final CSVFormat format = CSVFormat.DEFAULT;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
@@ -1,0 +1,70 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import edu.ucsb.cs156.happiercows.entities.ReportLine;
+
+/*
+ * This code is based on 
+ * <a href="https://bezkoder.com/spring-boot-download-csv-file/">https://bezkoder.com/spring-boot-download-csv-file/</a>
+ * and provides a way to serve up a CSV file containing information associated
+ * with an instructor report.
+ */
+
+public class ReportCSVHelper {
+
+  public static ByteArrayInputStream toCSV(Iterable<ReportLine> lines) {
+    final CSVFormat format = CSVFormat.DEFAULT;
+
+    List<String> headers = Arrays.asList(
+      "id",
+      "reportId",
+      "userId",
+      "username",
+      "totalWealth",
+      "numOfCows",
+      "avgCowHealth",
+      "cowsBought",
+      "cowsSold",
+      "cowDeaths",
+      "reportDate"
+    );
+    
+    try (
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format);) {
+
+      csvPrinter.printRecord(headers);
+      
+
+      for (ReportLine line : lines) {
+        List<String> data = Arrays.asList(
+          String.valueOf(line.getId()),
+          String.valueOf(line.getReportId()),
+          String.valueOf(line.getUserId()),
+          line.getUsername(),
+          String.valueOf(line.getTotalWealth()),
+          String.valueOf(line.getNumOfCows()),
+          String.valueOf(line.getAvgCowHealth()),
+          String.valueOf(line.getCowsBought()),
+          String.valueOf(line.getCowsSold()),
+          String.valueOf(line.getCowDeaths()),
+          String.valueOf(line.getCreateDate())
+        );
+
+        csvPrinter.printRecord(data);
+      }
+
+      csvPrinter.flush();
+      return new ByteArrayInputStream(out.toByteArray());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to import data to CSV file: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
@@ -1,26 +1,14 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import java.util.Optional;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
-import edu.ucsb.cs156.happiercows.entities.User;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
-import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
-
 import edu.ucsb.cs156.happiercows.services.ReportService;
-
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @AllArgsConstructor
 public class InstructorReportJob implements JobContextConsumer {
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
@@ -1,27 +1,13 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import java.util.Optional;
 
-import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
-import edu.ucsb.cs156.happiercows.entities.User;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
-import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
-
 import edu.ucsb.cs156.happiercows.services.ReportService;
-
-
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @AllArgsConstructor
 public class InstructorReportJobSingleCommons implements JobContextConsumer {
 


### PR DESCRIPTION
In this PR, we add the ability for an admin to download a CSV copy of the report lines associated with a given report.

# Screenshots

What's new is the Download CSV button seen in this screenshot:

<img width="1085" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/404ebcbe-6792-4703-a358-4a8120aada37">

When you click it, you get a CSV file such as this one, shown here in the "Numbers" program on MacOS:

<img width="939" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/ed74a10b-3eff-4eb4-8b4e-dacbe75b1533">

# To test

1. Login as an admin
1. Create a commons
2. Join the commons
3. Buy a cow or two
4. Go to the Admin / Jobs page and run the instructor report
5. Go to the Admin/ Instructor Reports Page
6. Click View Report
7. Click Download CSV
8. Compare the contents of the CSV with the report; they should match.