### PR TITLE
pc - make the jobs page "paged", meaning show only 10 jobs at a time

### DIFF
--- a/frontend/src/fixtures/pagedJobsFixtures.js
+++ b/frontend/src/fixtures/pagedJobsFixtures.js
@@ -1,0 +1,461 @@
+const jobsFixtures = {
+    emptyPage: {
+        "content": [],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 10,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 0,
+        "totalElements": 0,
+        "last": true,
+        "size": 10,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 0,
+        "first": true,
+        "empty": true
+    },
+    onePage:
+    {
+        "content": [
+            {
+                "id": 120,
+                "createdAt": "2023-08-08T12:14:00.041855-07:00",
+                "updatedAt": "2023-08-08T12:14:00.211631-07:00",
+                "status": "complete",
+                "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016\n old cow health: 54.40000000000016, new cow health: 53.600000000000165\nCow health has been updated!"
+            },
+            {
+                "id": 119,
+                "createdAt": "2023-08-08T12:13:00.052523-07:00",
+                "updatedAt": "2023-08-08T12:13:00.297008-07:00",
+                "status": "complete",
+                "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10210.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10225.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10455.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10490.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016, totalWealth: $2604.80\nProfit for user: Phill Conrad is: $54.40, newWealth: $2659.20\nCows have been milked!"
+            },
+            {
+                "id": 118,
+                "createdAt": "2023-08-08T11:42:22.695515-07:00",
+                "updatedAt": "2023-08-08T11:42:25.245356-07:00",
+                "status": "complete",
+                "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+            },
+            {
+                "id": 117,
+                "createdAt": "2023-08-08T11:42:22.556153-07:00",
+                "updatedAt": "2023-08-08T11:42:25.057215-07:00",
+                "status": "complete",
+                "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+            },
+            {
+                "id": 116,
+                "createdAt": "2023-08-08T11:42:22.398358-07:00",
+                "updatedAt": "2023-08-08T11:42:24.200089-07:00",
+                "status": "complete",
+                "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+            },
+            {
+                "id": 115,
+                "createdAt": "2023-08-08T11:42:22.296369-07:00",
+                "updatedAt": "2023-08-08T11:42:24.04618-07:00",
+                "status": "complete",
+                "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+            }
+        ],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 10,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 1,
+        "totalElements": 6,
+        "last": true,
+        "size": 10,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 6,
+        "first": true,
+        "empty": false
+    },
+    fourPages: [
+        {
+            "content": [
+                {
+                    "id": 120,
+                    "createdAt": "2023-08-08T12:14:00.041855-07:00",
+                    "updatedAt": "2023-08-08T12:14:00.211631-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016\n old cow health: 54.40000000000016, new cow health: 53.600000000000165\nCow health has been updated!"
+                },
+                {
+                    "id": 119,
+                    "createdAt": "2023-08-08T12:13:00.052523-07:00",
+                    "updatedAt": "2023-08-08T12:13:00.297008-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10210.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10225.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10455.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10490.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016, totalWealth: $2604.80\nProfit for user: Phill Conrad is: $54.40, newWealth: $2659.20\nCows have been milked!"
+                },
+                {
+                    "id": 118,
+                    "createdAt": "2023-08-08T11:42:22.695515-07:00",
+                    "updatedAt": "2023-08-08T11:42:25.245356-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 117,
+                    "createdAt": "2023-08-08T11:42:22.556153-07:00",
+                    "updatedAt": "2023-08-08T11:42:25.057215-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 116,
+                    "createdAt": "2023-08-08T11:42:22.398358-07:00",
+                    "updatedAt": "2023-08-08T11:42:24.200089-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 115,
+                    "createdAt": "2023-08-08T11:42:22.296369-07:00",
+                    "updatedAt": "2023-08-08T11:42:24.04618-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 114,
+                    "createdAt": "2023-08-08T11:42:22.14669-07:00",
+                    "updatedAt": "2023-08-08T11:42:23.156125-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 113,
+                    "createdAt": "2023-08-08T11:42:21.995817-07:00",
+                    "updatedAt": "2023-08-08T11:42:23.003502-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 112,
+                    "createdAt": "2023-08-08T11:42:02.244951-07:00",
+                    "updatedAt": "2023-08-08T11:42:05.295741-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 111,
+                    "createdAt": "2023-08-08T11:42:02.045677-07:00",
+                    "updatedAt": "2023-08-08T11:42:04.554159-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 0,
+                "pageNumber": 0,
+                "pageSize": 10,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 4,
+            "totalElements": 34,
+            "last": false,
+            "size": 10,
+            "number": 0,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 10,
+            "first": true,
+            "empty": false
+        },
+        {
+            "content": [
+                {
+                    "id": 110,
+                    "createdAt": "2023-08-08T11:42:01.894951-07:00",
+                    "updatedAt": "2023-08-08T11:42:04.251314-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 109,
+                    "createdAt": "2023-08-08T11:42:01.745402-07:00",
+                    "updatedAt": "2023-08-08T11:42:03.50618-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 108,
+                    "createdAt": "2023-08-08T11:42:01.598764-07:00",
+                    "updatedAt": "2023-08-08T11:42:03.204012-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 107,
+                    "createdAt": "2023-08-08T11:42:01.449214-07:00",
+                    "updatedAt": "2023-08-08T11:42:02.495829-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 106,
+                    "createdAt": "2023-08-08T11:42:01.145541-07:00",
+                    "updatedAt": "2023-08-08T11:42:02.156006-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 105,
+                    "createdAt": "2023-08-08T11:42:00.01123-07:00",
+                    "updatedAt": "2023-08-08T11:42:00.204043-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 55.20000000000016\n old cow health: 55.20000000000016, new cow health: 54.40000000000016\nCow health has been updated!"
+                },
+                {
+                    "id": 104,
+                    "createdAt": "2023-08-08T11:41:52.398066-07:00",
+                    "updatedAt": "2023-08-08T11:41:53.445837-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 103,
+                    "createdAt": "2023-08-08T11:41:51.799791-07:00",
+                    "updatedAt": "2023-08-08T11:41:52.845574-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 102,
+                    "createdAt": "2023-08-08T11:41:51.10517-07:00",
+                    "updatedAt": "2023-08-08T11:41:52.153975-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 101,
+                    "createdAt": "2023-08-08T11:41:50.294837-07:00",
+                    "updatedAt": "2023-08-08T11:41:51.306282-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 10,
+                "pageNumber": 1,
+                "pageSize": 10,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 4,
+            "totalElements": 34,
+            "last": false,
+            "size": 10,
+            "number": 1,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 10,
+            "first": false,
+            "empty": false
+        },
+        {
+            "content": [
+                {
+                    "id": 100,
+                    "createdAt": "2023-08-08T11:41:49.5453-07:00",
+                    "updatedAt": "2023-08-08T11:41:50.554996-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 99,
+                    "createdAt": "2023-08-08T11:41:34.310896-07:00",
+                    "updatedAt": "2023-08-08T11:41:35.446034-07:00",
+                    "status": "complete",
+                    "log": "Hello World! from test job!\nauthentication is not null\nGoodbye from test job!"
+                },
+                {
+                    "id": 98,
+                    "createdAt": "2023-08-08T11:35:00.017525-07:00",
+                    "updatedAt": "2023-08-08T11:35:00.158433-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 56.000000000000156\n old cow health: 56.000000000000156, new cow health: 55.20000000000016\nCow health has been updated!"
+                },
+                {
+                    "id": 97,
+                    "createdAt": "2023-08-08T11:28:00.010639-07:00",
+                    "updatedAt": "2023-08-08T11:28:00.242304-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 56.80000000000015\n old cow health: 56.80000000000015, new cow health: 56.000000000000156\nCow health has been updated!"
+                },
+                {
+                    "id": 96,
+                    "createdAt": "2023-08-08T11:26:00.03317-07:00",
+                    "updatedAt": "2023-08-08T11:26:00.193107-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10195.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10210.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10420.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10455.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 56.80000000000015, totalWealth: $2548.00\nProfit for user: Phill Conrad is: $56.80, newWealth: $2604.80\nCows have been milked!"
+                },
+                {
+                    "id": 95,
+                    "createdAt": "2023-08-08T11:13:00.025739-07:00",
+                    "updatedAt": "2023-08-08T11:13:00.285787-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10180.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10195.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10385.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10420.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 56.80000000000015, totalWealth: $2491.20\nProfit for user: Phill Conrad is: $56.80, newWealth: $2548.00\nCows have been milked!"
+                },
+                {
+                    "id": 94,
+                    "createdAt": "2023-08-08T10:14:00.008943-07:00",
+                    "updatedAt": "2023-08-08T10:14:00.071925-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 57.60000000000015\n old cow health: 57.60000000000015, new cow health: 56.80000000000015\nCow health has been updated!"
+                },
+                {
+                    "id": 93,
+                    "createdAt": "2023-08-08T10:13:00.028367-07:00",
+                    "updatedAt": "2023-08-08T10:13:00.143601-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10165.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10180.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10350.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10385.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 57.60000000000015, totalWealth: $2433.60\nProfit for user: Phill Conrad is: $57.60, newWealth: $2491.20\nCows have been milked!"
+                },
+                {
+                    "id": 92,
+                    "createdAt": "2023-08-08T10:07:00.011244-07:00",
+                    "updatedAt": "2023-08-08T10:07:00.059177-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 58.40000000000015\n old cow health: 58.40000000000015, new cow health: 57.60000000000015\nCow health has been updated!"
+                },
+                {
+                    "id": 91,
+                    "createdAt": "2023-08-08T10:00:00.012706-07:00",
+                    "updatedAt": "2023-08-08T10:00:00.087001-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10150.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10165.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10315.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10350.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 58.40000000000015, totalWealth: $2375.20\nProfit for user: Phill Conrad is: $58.40, newWealth: $2433.60\nCows have been milked!"
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 20,
+                "pageNumber": 2,
+                "pageSize": 10,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 4,
+            "totalElements": 34,
+            "last": false,
+            "size": 10,
+            "number": 2,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 10,
+            "first": false,
+            "empty": false
+        },
+        {
+            "content": [
+                {
+                    "id": 90,
+                    "createdAt": "2023-08-08T09:59:59.979338-07:00",
+                    "updatedAt": "2023-08-08T10:00:00.080441-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 58.40000000000015\n old cow health: 58.40000000000015, new cow health: 57.60000000000015\nCow health has been updated!"
+                },
+                {
+                    "id": 89,
+                    "createdAt": "2023-08-08T09:52:00.005894-07:00",
+                    "updatedAt": "2023-08-08T09:52:00.235908-07:00",
+                    "status": "complete",
+                    "log": "Starting to milk the cows\nMilking cows for Commons: Blue, Milk Price: $5.00\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0, totalWealth: $10135.00\nProfit for user: Phill Conrad is: $15.00, newWealth: $10150.00\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0, totalWealth: $10280.00\nProfit for user: Phillip Conrad is: $35.00, newWealth: $10315.00\nMilking cows for Commons: Red, Milk Price: $10.00\nUser: Phill Conrad, numCows: 10, cowHealth: 58.40000000000015, totalWealth: $2316.80\nProfit for user: Phill Conrad is: $58.40, newWealth: $2375.20\nCows have been milked!"
+                },
+                {
+                    "id": 88,
+                    "createdAt": "2023-08-08T09:49:00.023409-07:00",
+                    "updatedAt": "2023-08-08T09:49:00.154346-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 59.200000000000145\n old cow health: 59.200000000000145, new cow health: 58.40000000000015\nCow health has been updated!"
+                },
+                {
+                    "id": 87,
+                    "createdAt": "2023-08-08T09:42:00.01134-07:00",
+                    "updatedAt": "2023-08-08T09:42:00.07881-07:00",
+                    "status": "complete",
+                    "log": "Updating cow health...\nCommons Blue, degradationRate: 0.1, carryingCapacity: 10\nUser: Phill Conrad, numCows: 3, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nUser: Phillip Conrad, numCows: 7, cowHealth: 100.0\n old cow health: 100.0, new cow health: 100.0\nCommons Red, degradationRate: 0.1, carryingCapacity: 2\nUser: Phill Conrad, numCows: 10, cowHealth: 60.00000000000014\n old cow health: 60.00000000000014, new cow health: 59.200000000000145\nCow health has been updated!"
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 30,
+                "pageNumber": 3,
+                "pageSize": 10,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 4,
+            "totalElements": 34,
+            "last": true,
+            "size": 10,
+            "number": 3,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 4,
+            "first": false,
+            "empty": false
+        }
+    ]
+
+};
+
+export default jobsFixtures;

--- a/frontend/src/main/components/Jobs/PagedJobsTable.js
+++ b/frontend/src/main/components/Jobs/PagedJobsTable.js
@@ -1,0 +1,85 @@
+import React from "react";
+import OurTable, { PlaintextColumn, DateColumn } from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
+
+export default function PagedJobsTable() {
+
+    const testId = "PagedJobsTable";
+    const refreshJobsIntervalMilliseconds = 5000;
+
+    const [selectedPage, setSelectedPage] = React.useState(0);
+
+    const pageSize = 10;
+
+    // Stryker disable all
+    const {
+        data: page
+    } = useBackend(
+        ["/api/jobs/all"],
+        {
+            method: "GET",
+            url: "/api/jobs/all/pageable",
+            params: {
+                page: selectedPage,
+                size: pageSize,
+            }
+        },
+        {content: [], totalPages: 0},
+        { refetchInterval: refreshJobsIntervalMilliseconds }
+    );
+    // Stryker restore  all
+
+    const testid = "PagedJobsTable";
+
+    const previousPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage - 1);
+        }
+    }
+
+    const nextPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage + 1);
+        }
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        DateColumn('Created', (cell) => cell.row.original.createdAt),
+        DateColumn('Updated', (cell) => cell.row.original.updatedAt),
+        {
+            Header: 'Status',
+            accessor: 'status'
+        },
+        PlaintextColumn('Log', (cell) => cell.row.original.log),
+    ];
+
+    const sortees = React.useMemo(
+        () => [
+            {
+                id: "id",
+                desc: true
+            }
+        ],
+        // Stryker disable next-line all
+        []
+    );
+
+    return (
+        <>
+            <p>Page: {selectedPage + 1}</p>
+            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
+            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            < OurTable
+                data={page.content}
+                columns={columns}
+                testid={testid}
+                initialState={{ sortBy: sortees }}
+            />
+        </>
+    );
+}; 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,7 +1,6 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import JobsTable from "main/components/Jobs/JobsTable";
-import { useBackend } from "main/utils/useBackend";
+import PagedJobsTable from "main/components/Jobs/PagedJobsTable";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
@@ -14,7 +13,6 @@ import { useBackendMutation } from "main/utils/useBackend";
 import SetCowHealthForm from "main/components/Jobs/SetCowHealthForm";
 
 const AdminJobsPage = () => {
-  const refreshJobsIntervalMilliseconds = 5000;
 
   // *** Test job ***
 
@@ -34,22 +32,7 @@ const AdminJobsPage = () => {
     testJobMutation.mutate(data);
   };
 
-  // Stryker disable all
-  const {
-    data: jobs,
-    error: _error,
-    status: _status,
-  } = useBackend(
-    ["/api/jobs/all"],
-    {
-      method: "GET",
-      url: "/api/jobs/all",
-    },
-    [],
-    { refetchInterval: refreshJobsIntervalMilliseconds }
-  );
-  // Stryker restore  all
-
+  
   // *** SetCowHealth job ***
 
   const objectToAxiosParamsSetCowHealthJob = (data) => ({
@@ -194,7 +177,7 @@ return (
     </Accordion>
 
     <h2 className="p-3">Job Status</h2>
-    <JobsTable jobs={jobs} />
+    <PagedJobsTable />
   </BasicLayout>
 );
 };

--- a/frontend/src/stories/components/Jobs/PagedJobsTable.stories.js
+++ b/frontend/src/stories/components/Jobs/PagedJobsTable.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import PagedJobsTable from "main/components/Jobs/PagedJobsTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+export default {
+    title: 'components/Leaderboard/PagedJobsTable',
+    component: PagedJobsTable
+};
+
+const Template = (args) => {
+    return (
+        <PagedJobsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    jobs: [],
+    nextPageCallback: () => { },
+    previousPageCallback: () => { }
+};
+
+export const SixJobs = Template.bind({});
+
+SixJobs.args = {
+    jobs: jobsFixtures.sixJobs,
+    nextPageCallback: () => { },
+    previousPageCallback: () => { }
+};

--- a/frontend/src/tests/components/Jobs/PagedJobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/PagedJobsTable.test.js
@@ -18,7 +18,7 @@ describe("PagedJobsTable tests", () => {
     axiosMock.resetHistory();
   });
 
-  test("renders correct content ", async () => {
+  test("renders correct content", async () => {
 
     // arrange
 
@@ -83,7 +83,7 @@ describe("PagedJobsTable tests", () => {
     expect(previousButton).toBeDisabled();
   });
 
-  test("buttons are disabled where there are zero pages ", async () => {
+  test("buttons are disabled where there are zero pages", async () => {
 
     // arrange
 

--- a/frontend/src/tests/components/Jobs/PagedJobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/PagedJobsTable.test.js
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import PagedJobsTable from "main/components/Jobs/PagedJobsTable";
+import pagedJobsFixtures from "fixtures/pagedJobsFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PagedJobsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "PagedJobsTable";
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+  test("renders correct content ", async () => {
+
+    // arrange
+
+    axiosMock.onGet("/api/jobs/all/pageable").reply(200, pagedJobsFixtures.onePage);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedJobsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert
+    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
+    const expectedFields = ['id', 'Created', 'Updated', 'status', 'Log'];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
+    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1"
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Created`)
+    ).toHaveTextContent("8/8/2023, 12:14:00");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Updated`)
+    ).toHaveTextContent("8/8/2023, 12:14:00");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`)
+    ).toHaveTextContent("complete");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Log`)
+    ).toHaveTextContent(`Updating cow health...Commons Blue, degradationRate: 0.1, carryingCapacity: 10User: Phill Conrad, numCows: 3, cowHealth: 100.0 old cow health: 100.0, new cow health: 100.0User: Phillip Conrad, numCows: 7, cowHealth: 100.0 old cow health: 100.0, new cow health: 100.0Commons Red, degradationRate: 0.1, carryingCapacity: 2User: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016 old cow health: 54.40000000000016, new cow health: 53.600000000000165Cow health has been updated!`);
+
+    expect(screen.getByTestId(`${testId}-header-id-sort-carets`)).toHaveTextContent("🔽");
+
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toBeDisabled();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+    expect(previousButton).toBeDisabled();
+  });
+
+  test("buttons are disabled where there are zero pages ", async () => {
+
+    // arrange
+
+    axiosMock.onGet("/api/jobs/all/pageable").reply(200, pagedJobsFixtures.emptyPage);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedJobsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
+    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toBeDisabled();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+    expect(previousButton).toBeDisabled();
+  });
+
+
+  test("renders correct content with multiple pages", async () => {
+    // arrange
+
+    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 0, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[0]);
+    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 1, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[1]);
+    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 2, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[2]);
+    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 3, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[3]);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedJobsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert
+    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
+    const expectedFields = ['id', 'Created', 'Updated', 'status', 'Log'];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
+    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+
+    expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+    expect(previousButton).toBeEnabled();
+    expect(nextButton).toBeEnabled();
+
+    fireEvent.click(previousButton);
+    await waitFor(() => { expect(screen.getByText(`Page: 1`)).toBeInTheDocument();});
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+
+    fireEvent.click(nextButton);
+    await waitFor(() => { expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+
+    fireEvent.click(nextButton);
+    await waitFor(() => { expect(screen.getByText(`Page: 3`)).toBeInTheDocument();});
+
+    fireEvent.click(nextButton);
+    await waitFor(() => { expect(screen.getByText(`Page: 4`)).toBeInTheDocument();});
+    expect(previousButton).toBeEnabled();
+    expect(nextButton).toBeDisabled();
+  });
+
+});
+

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -7,9 +7,8 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import jobsFixtures from "fixtures/jobsFixtures";
+import pagedJobsFixtures from "fixtures/pagedJobsFixtures";
 import commonsFixtures from "../../fixtures/commonsFixtures";
-
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -35,7 +34,7 @@ describe("AdminJobsPage tests", () => {
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.adminUser);
-    axiosMock.onGet("/api/jobs/all").reply(200, jobsFixtures.sixJobs);
+    axiosMock.onGet("/api/jobs/all/pageable").reply(200, pagedJobsFixtures.onePage);
 
     // see: https://ucsb-cs156.github.io/topics/testing/testing_jest.html#hiding-the-wall-of-red
     jest.spyOn(console, 'error')
@@ -63,25 +62,7 @@ describe("AdminJobsPage tests", () => {
     expect(await screen.findByText("Set Cow Health for a Specific Commons")).toBeInTheDocument();
     expect(await screen.findByText("Update Cow Health")).toBeInTheDocument();
     expect(await screen.findByText("Milk The Cows")).toBeInTheDocument();
-    expect(await screen.findByText("Instructor Report")).toBeInTheDocument();
-
-    const testId = "JobsTable";
-
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "1"
-    );
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Created`)
-    ).toHaveTextContent("11/13/2022, 19:49:58");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Updated`)
-    ).toHaveTextContent("11/13/2022, 19:49:59");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-status`)
-    ).toHaveTextContent("complete");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Log`)
-    ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+    expect(await screen.findByText("Instructor Report")).toBeInTheDocument();  
   });
 
   test("user can submit a test job", async () => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -5,18 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,19 +23,15 @@ import edu.ucsb.cs156.happiercows.jobs.InstructorReportJob;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJobSingleCommons;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJobSingleCommonsFactory;
-import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJob;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
-import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 
 
-
-@Slf4j
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")
 @RestController
@@ -83,7 +75,7 @@ public class JobsController extends ApiController {
          @Parameter(name="page") @RequestParam int page,
          @Parameter(name="size") @RequestParam int size
     ) {
-        Page<Job> jobs = jobsRepository.findAll(PageRequest.of(page, size));
+        Page<Job> jobs = jobsRepository.findAll(PageRequest.of(page, size, Sort.by("id").descending()));
         return jobs;
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -9,6 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJob;
@@ -68,6 +73,17 @@ public class JobsController extends ApiController {
     @GetMapping("/all")
     public Iterable<Job> allJobs() {
         Iterable<Job> jobs = jobsRepository.findAll();
+        return jobs;
+    }
+
+    @Operation(summary = "List all jobs")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all/pageable")
+    public Page<Job> allJobsPaged(
+         @Parameter(name="page") @RequestParam int page,
+         @Parameter(name="size") @RequestParam int size
+    ) {
+        Page<Job> jobs = jobsRepository.findAll(PageRequest.of(page, size));
         return jobs;
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/jobs/JobsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/jobs/JobsRepository.java
@@ -4,8 +4,11 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 
 @Repository
 public interface JobsRepository extends CrudRepository<Job, Long> {
-
+    public Page<Job> findAll(Pageable pageable);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -132,31 +132,6 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 Page<Job> expectedJobPage = new PageImpl<>(expectedJobs, pageRequest, expectedJobs.size());
 
-                // Paged<Job> expectedJobPage = new Paged<Job>();
-                // expectedJobPage.setContent(expectedJobs);
-                // Sort sort = Sort.builder().empty(true).sorted(false).unsorted(true).build();
-                // expectedJobPage.setPageable(
-                //         Pageable.builder()
-                //         .sort(sort)
-                //         .offset(0)
-                //         .pageNumber(0)
-                //         .pageSize(5)
-                //         .paged(true)
-                //         .unpaged(false)
-                //         .build()
-                //         );
-
-                // expectedJobPage.setTotalPages(18);
-                // expectedJobPage.setTotalElements(87L);
-                // expectedJobPage.setLast(false);
-                // expectedJobPage.setSize(5);
-                // expectedJobPage.setNumber(0);
-                // expectedJobPage.setSort(sort);
-                // expectedJobPage.setNumberOfElements(5);
-                // expectedJobPage.setFirst(true);
-                // expectedJobPage.setEmpty(false);
-
-             
                 when(jobsRepository.findAll(any())).thenReturn(expectedJobPage);
 
                 // act

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -25,6 +25,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -54,228 +57,288 @@ import lombok.extern.slf4j.Slf4j;
 @AutoConfigureDataJpa
 public class JobsControllerTests extends ControllerTestCase {
 
-    @MockBean
-    JobsRepository jobsRepository;
+        @MockBean
+        JobsRepository jobsRepository;
 
-    @MockBean
-    UserRepository userRepository;
+        @MockBean
+        UserRepository userRepository;
 
-    @Autowired
-    JobService jobService;
+        @Autowired
+        JobService jobService;
 
-    @Autowired
-    ObjectMapper objectMapper;
+        @Autowired
+        ObjectMapper objectMapper;
 
-    @MockBean
-    CommonsRepository commonsRepository;
+        @MockBean
+        CommonsRepository commonsRepository;
 
-    @MockBean
-    UserCommonsRepository userCommonsRepository;
+        @MockBean
+        UserCommonsRepository userCommonsRepository;
 
-    @MockBean
-    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+        @MockBean
+        UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
-    @MockBean
-    MilkTheCowsJobFactory milkTheCowsJobFactory;
+        @MockBean
+        MilkTheCowsJobFactory milkTheCowsJobFactory;
 
-    @MockBean
-    SetCowHealthJobFactory setCowHealthJobFactory;
+        @MockBean
+        SetCowHealthJobFactory setCowHealthJobFactory;
 
-    @MockBean
-    InstructorReportJobFactory instructorReportJobFactory;
+        @MockBean
+        InstructorReportJobFactory instructorReportJobFactory;
 
-    @MockBean
-    InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+        @MockBean
+        InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_get_all_jobs() throws Exception {
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_get_all_jobs() throws Exception {
 
-        // arrange
+                // arrange
 
-        Job job1 = Job.builder().log("this is job 1").build();
-        Job job2 = Job.builder().log("this is job 2").build();
+                Job job1 = Job.builder().log("this is job 1").build();
+                Job job2 = Job.builder().log("this is job 2").build();
 
-        ArrayList<Job> expectedJobs = new ArrayList<>();
-        expectedJobs.addAll(Arrays.asList(job1, job2));
+                ArrayList<Job> expectedJobs = new ArrayList<>();
+                expectedJobs.addAll(Arrays.asList(job1, job2));
 
-        when(jobsRepository.findAll()).thenReturn(expectedJobs);
+                when(jobsRepository.findAll()).thenReturn(expectedJobs);
 
-        // act
-        MvcResult response = mockMvc.perform(get("/api/jobs/all"))
-                .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/jobs/all"))
+                                .andExpect(status().isOk()).andReturn();
 
-        // assert
+                // assert
 
-        verify(jobsRepository, atLeastOnce()).findAll();
-        String expectedJson = mapper.writeValueAsString(expectedJobs);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
+                verify(jobsRepository, atLeastOnce()).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedJobs);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_test_job() throws Exception {
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_get_all_jobs_paged() throws Exception {
 
-        // arrange
+                // arrange
 
-        User user = currentUserService.getUser();
+                PageRequest pageRequest = PageRequest.of(0, 5);
 
-        Job jobStarted = Job.builder()
-                .id(0L)
-                .createdBy(user)
-                .createdAt(null)
-                .updatedAt(null)
-                .status("running")
-                .log("Hello World! from test job!\nauthentication is not null")
-                .build();
+                Job job1 = Job.builder().log("this is job 1").build();
+                Job job2 = Job.builder().log("this is job 2").build();
 
-        Job jobCompleted = Job.builder()
-                .id(0L)
-                .createdBy(user)
-                .createdAt(null)
-                .updatedAt(null)
-                .status("complete")
-                .log("Hello World! from test job!\nauthentication is not null\nGoodbye from test job!")
-                .build();
+                ArrayList<Job> expectedJobs = new ArrayList<>();
+                expectedJobs.addAll(Arrays.asList(job1, job2));
 
-        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+                Page<Job> expectedJobPage = new PageImpl<>(expectedJobs, pageRequest, expectedJobs.size());
 
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                // Paged<Job> expectedJobPage = new Paged<Job>();
+                // expectedJobPage.setContent(expectedJobs);
+                // Sort sort = Sort.builder().empty(true).sorted(false).unsorted(true).build();
+                // expectedJobPage.setPageable(
+                //         Pageable.builder()
+                //         .sort(sort)
+                //         .offset(0)
+                //         .pageNumber(0)
+                //         .pageSize(5)
+                //         .paged(true)
+                //         .unpaged(false)
+                //         .build()
+                //         );
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                // expectedJobPage.setTotalPages(18);
+                // expectedJobPage.setTotalElements(87L);
+                // expectedJobPage.setLast(false);
+                // expectedJobPage.setSize(5);
+                // expectedJobPage.setNumber(0);
+                // expectedJobPage.setSort(sort);
+                // expectedJobPage.setNumberOfElements(5);
+                // expectedJobPage.setFirst(true);
+                // expectedJobPage.setEmpty(false);
 
-        assertEquals("running", jobReturned.getStatus());
+             
+                when(jobsRepository.findAll(any())).thenReturn(expectedJobPage);
 
-        await().atMost(1, SECONDS)
-                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
-        await().atMost(10, SECONDS)
-                .untilAsserted(() -> verify(jobsRepository, times(5)).save(eq(jobCompleted)));
-    }
+                // act
+                MvcResult response = mockMvc.perform(get("/api/jobs/all/pageable?page=0&size=10"))
+                                .andExpect(status().isOk()).andReturn();
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_test_job_that_fails() throws Exception {
+                // assert
 
-        // arrange
+                verify(jobsRepository, atLeastOnce()).findAll(any());
 
-        User user = currentUserService.getUser();
+                String expectedJson = mapper.writeValueAsString(expectedJobPage);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-        Job jobStarted = Job.builder()
-                .id(0L)
-                .createdBy(user)
-                .createdAt(null)
-                .updatedAt(null)
-                .status("running")
-                .log("Hello World! from test job!\nauthentication is not null")
-                .build();
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_test_job() throws Exception {
 
-        Job jobFailed = Job.builder()
-                .id(0L)
-                .createdBy(user)
-                .createdAt(null)
-                .updatedAt(null)
-                .status("error")
-                .log("Hello World! from test job!\nauthentication is not null\nFail!")
-                .build();
+                // arrange
 
-        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+                User user = currentUserService.getUser();
 
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                Job jobStarted = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("running")
+                                .log("Hello World! from test job!\nauthentication is not null")
+                                .build();
 
-        String responseString = response.getResponse().getContentAsString();
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                Job jobCompleted = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("complete")
+                                .log("Hello World! from test job!\nauthentication is not null\nGoodbye from test job!")
+                                .build();
 
-        assertEquals("running", jobReturned.getStatus());
+                when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
 
-        await().atMost(1, SECONDS)
-                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        await().atMost(10, SECONDS)
-                .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobFailed)));
-    }
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_milk_the_cows_job() throws Exception {
-        
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/milkthecowjob").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                assertEquals("running", jobReturned.getStatus());
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        log.info("responseString={}", responseString);
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                await().atMost(1, SECONDS)
+                                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
+                await().atMost(10, SECONDS)
+                                .untilAsserted(() -> verify(jobsRepository, times(5)).save(eq(jobCompleted)));
+        }
 
-        assertNotNull(jobReturned.getStatus());
-    }
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_test_job_that_fails() throws Exception {
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_instructor_report_job() throws Exception {
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/instructorreport").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                // arrange
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        log.info("responseString={}", responseString);
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                User user = currentUserService.getUser();
 
-        assertNotNull(jobReturned.getStatus());
-    }
+                Job jobStarted = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("running")
+                                .log("Hello World! from test job!\nauthentication is not null")
+                                .build();
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_update_cow_health_job() throws Exception {
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updatecowhealth").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                Job jobFailed = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("error")
+                                .log("Hello World! from test job!\nauthentication is not null\nFail!")
+                                .build();
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        log.info("responseString={}", responseString);
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
 
-        assertNotNull(jobReturned.getStatus());
-    }
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_set_cow_health_job() throws Exception {
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/setcowhealth?commonsID=1&health=20").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                String responseString = response.getResponse().getContentAsString();
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        log.info("responseString={}", responseString);
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+                assertEquals("running", jobReturned.getStatus());
 
-        assertNotNull(jobReturned.getStatus());
-    }
+                await().atMost(1, SECONDS)
+                                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void admin_can_launch_instructor_report_single_commons_job() throws Exception {
-        // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/instructorreportsinglecommons?commonsId=1").with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                await().atMost(10, SECONDS)
+                                .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobFailed)));
+        }
 
-        // assert
-        String responseString = response.getResponse().getContentAsString();
-        log.info("responseString={}", responseString);
-        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_milk_the_cows_job() throws Exception {
 
-        assertNotNull(jobReturned.getStatus());
-    }
+                // act
+                MvcResult response = mockMvc.perform(post("/api/jobs/launch/milkthecowjob").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_instructor_report_job() throws Exception {
+                // act
+                MvcResult response = mockMvc.perform(post("/api/jobs/launch/instructorreport").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_update_cow_health_job() throws Exception {
+                // act
+                MvcResult response = mockMvc.perform(post("/api/jobs/launch/updatecowhealth").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_set_cow_health_job() throws Exception {
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/setcowhealth?commonsID=1&health=20").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_instructor_report_single_commons_job() throws Exception {
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/instructorreportsinglecommons?commonsId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
 
 }


### PR DESCRIPTION
# Overview

In this PR, we update the jobs page to be paged (i.e. to only show a fixed number of jobs records at a time, instead of all available jobs records).

This is necessary because the jobs page was starting to load too slowly because of the large volume of jobs data available in production once there are several daily jobs running, with very long lines of output.

# Screenshots

Here is what the AdminJobsPage looked like before, on storybook:

<img width="793" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/4c16f60f-4ad6-4141-b8ae-e9694eb30937">

Unfortunately, the old storybook had no fixtures to populate the jobs table, so here's a screenshot of what that page looks like in the running app (on dokku):

<img width="1180" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/d8ad3450-bab2-4bf1-a35c-ef2a62706532">

If you look at the page, you'll see that it loads over 1000 jobs entries, which is not a good idea.


* <https://happycows.dokku-00.cs.ucsb.edu/admin/jobs>

What we want instead is to page them.  Here's what the new page looks like on storybook:

<img width="781" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/ae2e99fa-d355-4677-9711-aeefdc3d4255">

The page only loads the 10 most recent post, and then there are buttons to move forward or backwards one page at a time.  It will rarely be the case that anyone will want to see more than the 10 most recent jobs in any case.

At some point, we'll want to also consider adding a way to purge the logs of old jobs, but that's a separate issue beyond the scope of this PR.

# New swagger endpoints

There is also a new swagger endpoint that looks like this:

<img width="1240" alt="image" src="https://github.com/ucsb-cs156/proj-happycows/assets/1119017/f7bd63f5-8383-4f3f-afb3-bfc5e5fb259d">

It returns a Page<Job> which is an object that has both the first 10 jobs, and metadata about the total number of pages available.   We also sort the results from this controller endpoint in reverse order by id, so that the most recent job is always first.