### PR TITLE
sk - add manual deletes of UserCommons to DELETE commons endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -273,8 +273,8 @@ public class CommonsController extends ApiController {
         
         Iterable<UserCommons> userCommons = userCommonsRepository.findByCommonsId(id);
 
-        for (UserCommons userCommon : userCommons) {
-            userCommonsRepository.delete(userCommon);
+        for (UserCommons commons : userCommons) {
+            userCommonsRepository.delete(commons);
         }
 
         commonsRepository.findById(id)

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -270,6 +270,12 @@ public class CommonsController extends ApiController {
     @DeleteMapping("")
     public Object deleteCommons(
             @Parameter(name="id") @RequestParam Long id) {
+        
+        Iterable<UserCommons> userCommons = userCommonsRepository.findByCommonsId(id);
+
+        for (UserCommons userCommon : userCommons) {
+            userCommonsRepository.delete(userCommon);
+        }
 
         commonsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -751,7 +751,28 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .carryingCapacity(100)
                 .build();
 
+        UserCommons uc1 = UserCommons.builder()
+                .user(currentUserService.getUser())
+                .commons(c)
+                .username("1L")
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        UserCommons uc2 = UserCommons.builder()
+                .user(currentUserService.getUser())
+                .commons(c)
+                .username("3L")
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        List<UserCommons> userCommons = new ArrayList<>();
+        userCommons.add(uc1);
+        userCommons.add(uc2);
+
         when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        when(userCommonsRepository.findByCommonsId(2L)).thenReturn(userCommons);
         doNothing().when(commonsRepository).deleteById(2L);
 
         MvcResult response = mockMvc.perform(
@@ -761,6 +782,10 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         verify(commonsRepository, times(1)).findById(2L);
         verify(commonsRepository, times(1)).deleteById(2L);
+
+        verify(userCommonsRepository, times(1)).findByCommonsId(2L);
+        verify(userCommonsRepository, times(1)).delete(uc1);
+        verify(userCommonsRepository, times(1)).delete(uc2);
 
         String responseString = response.getResponse().getContentAsString();
 


### PR DESCRIPTION
## Overview
In this PR, we fix the error that prevented an admin from being able to delete a commons using the Confirm Delete modal. This is the feature corresponding to https://github.com/ucsb-cs156/proj-happycows/issues/51 

This change manually goes through all the UserCommons, querying by commons id and deletes them before the entire commons gets deleted.

## Tests
Updated CommonsControllerTests.java to mock the manual deletion of userCommons
Tested on localhost, delete button now works on the first try