### PR TITLE
Add tag environment variable in github action 98

### DIFF
--- a/.github/workflows/98-copy-issue-by-number.yml
+++ b/.github/workflows/98-copy-issue-by-number.yml
@@ -9,6 +9,7 @@ name: 98 - Copy specific issue from starter repo (creates new issue)
 env:
     GH_TOKEN: ${{ github.token }}
     STARTER: https://github.com/ucsb-cs156/proj-happycows
+    TAG: f23
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +30,7 @@ jobs:
         id: get-issues
         run: |
           number=${{ github.event.inputs.issue_number }}
-          GH_REPO=${{env.STARTER}} gh issue list -s open -l M23 --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
+          GH_REPO=${{env.STARTER}} gh issue list -s open -l ${{env.TAG}} --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
           cat issues.json
           {
                echo 'issues<<THIS_IS_THIS_EOF_MARKER'


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I modified github action 98 by adding ```TAG``` environment variable. And updated workflow should copy over a specific issue from happycows base repository with tags specified by ```TAG```.  

## Feedback Request
Please give suggestions on the following:
- I can't test the workflow locally, so is this the right way to do it?
