### PR TITLE
pc/ap - refactor job test code so that we don't need wiremock in ever…

### DIFF
--- a/src/test/java/edu/ucsb/cs156/happiercows/JobTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/JobTestCase.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.happiercows;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
+import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
+
+
+public abstract class JobTestCase {
+
+  @MockBean
+  WiremockService mockWiremockService;
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
@@ -9,13 +9,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(InstructorReportJobFactory.class)
 @AutoConfigureDataJpa
-public class InstructorReportJobFactoryTests {
+public class InstructorReportJobFactoryTests extends JobTestCase {
 
     @MockBean
     ReportService reportService;
@@ -25,9 +25,6 @@ public class InstructorReportJobFactoryTests {
 
     @Autowired
     InstructorReportJobFactory InstructorReportJobFactory;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
@@ -9,21 +9,19 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(InstructorReportJobSingleCommonsFactory.class)
 @AutoConfigureDataJpa
-public class InstructorReportJobSingleCommonsFactoryTests {
+public class InstructorReportJobSingleCommonsFactoryTests extends JobTestCase {
 
     @MockBean
     ReportService reportService;
  
     @Autowired
     InstructorReportJobSingleCommonsFactory InstructorReportJobSingleCommonsFactory;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
@@ -10,15 +10,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class InstructorReportJobSingleCommonsTests {
+public class InstructorReportJobSingleCommonsTests extends JobTestCase {
 
     @MockBean
     ReportService reportService;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
@@ -21,7 +22,7 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class InstructorReportJobTests {
+public class InstructorReportJobTests extends JobTestCase {
 
     @MockBean
     ReportService reportService;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryIndTests.java
@@ -9,15 +9,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(MilkTheCowsJobFactoryInd.class)
 @AutoConfigureDataJpa
-public class MilkTheCowsJobFactoryIndTests {
+public class MilkTheCowsJobFactoryIndTests extends JobTestCase {
 
     @MockBean
     CommonsRepository commonsRepository;
@@ -33,9 +33,6 @@ public class MilkTheCowsJobFactoryIndTests {
 
     @Autowired
     MilkTheCowsJobFactoryInd MilkTheCowsJobFactoryInd;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobFactoryTests.java
@@ -9,15 +9,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(MilkTheCowsJobFactory.class)
 @AutoConfigureDataJpa
-public class MilkTheCowsJobFactoryTests {
+public class MilkTheCowsJobFactoryTests extends JobTestCase {
 
     @MockBean
     CommonsRepository commonsRepository;
@@ -33,9 +33,6 @@ public class MilkTheCowsJobFactoryTests {
 
     @Autowired
     MilkTheCowsJobFactory MilkTheCowsJobFactory;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
@@ -21,12 +22,11 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class MilkTheCowsJobIndTests {
+public class MilkTheCowsJobIndTests extends JobTestCase {
     @Mock
     CommonsRepository commonsRepository;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
@@ -25,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class MilkTheCowsJobTests {
+public class MilkTheCowsJobTests extends JobTestCase {
     @Mock
     CommonsRepository commonsRepository;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactoryTests.java
@@ -9,13 +9,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.CommonStatsService;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(RecordCommonStatsJobFactory.class)
 @AutoConfigureDataJpa
-public class RecordCommonStatsJobFactoryTests {
+public class RecordCommonStatsJobFactoryTests extends JobTestCase {
 
     @MockBean
     CommonStatsService commonStatsService;
@@ -25,9 +25,6 @@ public class RecordCommonStatsJobFactoryTests {
 
     @Autowired
     RecordCommonStatsJobFactory RecordCommonStatsJobFactory;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.CommonStats;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
@@ -23,7 +24,7 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class RecordCommonStatsJobTests {
+public class RecordCommonStatsJobTests extends JobTestCase {
 
     @MockBean
     AverageCowHealthService averageCowHealthService;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 @RestClientTest(ScheduledJobs.class)
 @AutoConfigureDataJpa
-public class ScheduledJobsTests {
+public class ScheduledJobsTests extends JobTestCase {
 
     private class MockJobContextConsumer implements JobContextConsumer {
         @Override
@@ -40,9 +40,6 @@ public class ScheduledJobsTests {
 
     @MockBean
     private JobService jobService;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_runUpdateCowHealthJobBasedOnCron() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactoryTests.java
@@ -9,14 +9,14 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(SetCowHealthJobFactory.class)
 @AutoConfigureDataJpa
-public class SetCowHealthJobFactoryTests {
+public class SetCowHealthJobFactoryTests extends JobTestCase {
 
     @MockBean
     CommonsRepository commonsRepository;
@@ -29,9 +29,6 @@ public class SetCowHealthJobFactoryTests {
 
     @Autowired
     SetCowHealthJobFactory setCowHealthJobFactory;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class SetCowHealthJobTests {
+public class SetCowHealthJobTests extends JobTestCase {
     @Mock
     CommonsRepository commonsRepository;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
@@ -13,7 +14,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration 
-public class TestJobTests {
+public class TestJobTests extends JobTestCase {
 
     @Test
     void test_log_output_with_no_user() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryIndTests.java
@@ -9,15 +9,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.CommonsPlusBuilderService;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(UpdateCowHealthJobFactoryInd.class)
 @AutoConfigureDataJpa
-public class UpdateCowHealthJobFactoryIndTests {
+public class UpdateCowHealthJobFactoryIndTests extends JobTestCase {
 
     @MockBean
     CommonsRepository commonsRepository;
@@ -33,9 +33,6 @@ public class UpdateCowHealthJobFactoryIndTests {
 
     @Autowired
     UpdateCowHealthJobFactoryInd updateCowHealthJobFactoryInd;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -9,15 +9,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.CommonsPlusBuilderService;
-import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
 @RestClientTest(UpdateCowHealthJobFactory.class)
 @AutoConfigureDataJpa
-public class UpdateCowHealthJobFactoryTests {
+public class UpdateCowHealthJobFactoryTests extends JobTestCase {
 
     @MockBean
     CommonsRepository commonsRepository;
@@ -33,9 +33,6 @@ public class UpdateCowHealthJobFactoryTests {
 
     @MockBean
     CommonsPlusBuilderService commonsPlusBuilderService;
-
-    @MockBean
-    WiremockService mockWiremockService;
 
     @Test
     void test_create() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class UpdateCowHealthJobIndTests {
+public class UpdateCowHealthJobIndTests extends JobTestCase {
         @Mock
         CommonsRepository commonsRepository;
 
@@ -47,9 +48,6 @@ public class UpdateCowHealthJobIndTests {
 
         @Mock
         UpdateCowHealthJob updateCowHealthJob;
-
-
-
 
         private final User user = User
                         .builder()

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import edu.ucsb.cs156.happiercows.JobTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class UpdateCowHealthJobTests {
+public class UpdateCowHealthJobTests extends JobTestCase {
         @Mock
         CommonsRepository commonsRepository;
 


### PR DESCRIPTION
In this PR, we refactor the job testing code, adding a parent class so that we can just add the mock for the Wiremock Service once.