### PR TITLE
Fix broken integration test workflow

### DIFF
--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -24,5 +24,5 @@ jobs:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
 
-    - name: Run tests with Maven
-      run: INTEGRATION=true mvn -B test-compile failsafe:integration-test 
+    - name: Run IT tests with Maven
+      run: INTEGRATION=true mvn -B test-compile failsafe:integration-test failsafe:verify


### PR DESCRIPTION
In this PR I fix workflow `11-backend-integration`.

Before, when integration/end-to-end tests would fail, the action would still pass with a green check. This change ensures that it can correctly fail when the integration and end-to-end test suite fails. 
