### PR TITLE
pc - add two new strategies for health update formulas

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -1,29 +1,36 @@
 package edu.ucsb.cs156.happiercows.strategies;
 
-
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * The CowHealthUpdateStrategies enum provides a variety of strategies for updating cow health.
+ * The CowHealthUpdateStrategies enum provides a variety of strategies for
+ * updating cow health.
  *
- * For information on Java enum's, see the Oracle Java Tutorial on <a href="https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html">Enum Types</a>,
+ * For information on Java enum's, see the Oracle Java Tutorial on
+ * <a href="https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html">Enum
+ * Types</a>,
  * which are far more powerful in Java than enums in most other languages.
  */
 
 @Getter
 @AllArgsConstructor
+@Slf4j
 public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
 
-    Linear("Linear", "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
+    Linear("Linear",
+            "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
-            return uC.getCowHealth() - (totalCows - commonsPlus.getEffectiveCapacity()) * commonsPlus.getCommons().getDegradationRate();
+            return uC.getCowHealth()
+                    - (totalCows - commonsPlus.getEffectiveCapacity()) * commonsPlus.getCommons().getDegradationRate();
         }
     },
-    Constant("Constant", "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
+    Constant("Constant",
+            "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
             if (totalCows <= commonsPlus.getEffectiveCapacity()) {
@@ -37,6 +44,39 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
         @Override
         public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
             return uC.getCowHealth();
+        }
+    },
+    Milan("Milan",
+            "Cow health increases/decreases proportionally to the square of ratio of cows/total capacity according to a formula from Milan de Vries.") {
+        @Override
+        public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
+            double excess = totalCows - commonsPlus.getEffectiveCapacity();
+            double adjustmentFactor = 1.0;
+            double x = (excess / commonsPlus.getEffectiveCapacity());
+            if (excess > 0) {
+                adjustmentFactor = 1.0 - x * x;
+            } else {
+                adjustmentFactor = 1.0 + x * x;
+            }
+            adjustmentFactor = Math.max(0.0, adjustmentFactor);
+            return uC.getCowHealth() * adjustmentFactor;
+        }
+    },
+    Mattanjah("Mattanjah",
+            "Cow health increases/decreases proportionally to the square of ratio of excess/total capacity * degradation rate according to a formula from Mattanjah de Vries.") {
+        @Override
+        public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
+
+            double excess = totalCows - commonsPlus.getEffectiveCapacity();
+            double adjustmentFactor = 1.0;
+            double x = (excess / commonsPlus.getEffectiveCapacity()) * commonsPlus.getCommons().getDegradationRate();
+            if (excess > 0) {
+                adjustmentFactor = 1 - x * x;
+            } else {
+                adjustmentFactor = 1 + x * x;
+            }
+            adjustmentFactor = Math.max(0.0, adjustmentFactor);
+            return uC.getCowHealth() * adjustmentFactor;
         }
     };
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -53,10 +53,9 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
             double excess = totalCows - commonsPlus.getEffectiveCapacity();
             double adjustmentFactor = 1.0;
             double x = (excess / commonsPlus.getEffectiveCapacity());
-            if (excess > 0) {
-                adjustmentFactor = 1.0 - x * x;
-            } else {
-                adjustmentFactor = 1.0 + x * x;
+            if(excess != 0){
+                double sign = -1 * excess / Math.abs(excess);
+                adjustmentFactor = 1.0 + sign * x * x;
             }
             adjustmentFactor = Math.max(0.0, adjustmentFactor);
             return uC.getCowHealth() * adjustmentFactor;
@@ -70,10 +69,9 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
             double excess = totalCows - commonsPlus.getEffectiveCapacity();
             double adjustmentFactor = 1.0;
             double x = (excess / commonsPlus.getEffectiveCapacity()) * commonsPlus.getCommons().getDegradationRate();
-            if (excess > 0) {
-                adjustmentFactor = 1 - x * x;
-            } else {
-                adjustmentFactor = 1 + x * x;
+            if(excess != 0){
+                double sign = -1 * excess / Math.abs(excess);
+                adjustmentFactor = 1.0 + sign * x * x;
             }
             adjustmentFactor = Math.max(0.0, adjustmentFactor);
             return uC.getCowHealth() * adjustmentFactor;

--- a/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
@@ -18,48 +18,106 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CowHealthUpdateStrategyTests {
 
     Commons commons = Commons.builder()
-    .degradationRate(0.01)
-    .capacityPerUser(20)
-    .carryingCapacity(100)
-    .build();
-    UserCommons user = UserCommons.builder().cowHealth(50).build();
+            .degradationRate(0.01)
+            .capacityPerUser(20)
+            .carryingCapacity(100)
+            .build();
+    UserCommons uc = UserCommons.builder().cowHealth(50).build();
 
-    CommonsPlus commonsPlus = CommonsPlus.builder().commons(commons).totalCows(0).totalUsers(1).build();
-    
+    CommonsPlus commonsPlus = CommonsPlus.builder().commons(commons).totalUsers(1).build();
+
+    Commons commons1 = Commons.builder()
+            .degradationRate(1.0)
+            .capacityPerUser(1)
+            .carryingCapacity(1000)
+            .build();
+    UserCommons uc1 = UserCommons.builder().cowHealth(50).build();
+
+    CommonsPlus commonsPlus1 = CommonsPlus.builder().commons(commons1).totalUsers(1).build();
+
+    Commons commons2 = Commons.builder()
+            .degradationRate(2.0)
+            .capacityPerUser(1)
+            .carryingCapacity(1000)
+            .build();
+    UserCommons uc2 = UserCommons.builder().cowHealth(50).build();
+
+    CommonsPlus commonsPlus2 = CommonsPlus.builder().commons(commons2).totalUsers(1).build();
+
+    Commons commons0_5 = Commons.builder()
+            .degradationRate(0.5)
+            .capacityPerUser(1)
+            .carryingCapacity(1000)
+            .build();
+    UserCommons uc0_5 = UserCommons.builder().cowHealth(50).build();
+
+    CommonsPlus commonsPlus0_5 = CommonsPlus.builder().commons(commons0_5).totalUsers(1).build();
+
     @Test
     void get_name_and_description() {
         assertEquals("Linear", CowHealthUpdateStrategies.Linear.name());
         assertEquals("Linear", CowHealthUpdateStrategies.Linear.getDisplayName());
-        assertEquals("Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.", CowHealthUpdateStrategies.Linear.getDescription());
+        assertEquals(
+                "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.",
+                CowHealthUpdateStrategies.Linear.getDescription());
     }
-
-
 
     @Test
     void linear_updates_health_proportional_to_num_cows_over_capacity() {
         var formula = CowHealthUpdateStrategies.Linear;
 
-        assertEquals(49.9, formula.calculateNewCowHealth(commonsPlus, user, 110));
-        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 100));
-        assertEquals(50.1, formula.calculateNewCowHealth(commonsPlus, user, 90));
+        assertEquals(49.9, formula.calculateNewCowHealth(commonsPlus, uc, 110));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, uc, 100));
+        assertEquals(50.1, formula.calculateNewCowHealth(commonsPlus, uc, 90));
     }
 
     @Test
     void constant_changes_by_constant_amount() {
         var formula = CowHealthUpdateStrategies.Constant;
 
-        assertEquals(49.99, formula.calculateNewCowHealth(commonsPlus, user, 120));
-        assertEquals(49.99, formula.calculateNewCowHealth(commonsPlus, user, 110));
-        assertEquals(50.01, formula.calculateNewCowHealth(commonsPlus, user, 100));
-        assertEquals(50.01, formula.calculateNewCowHealth(commonsPlus, user, 90));
+        assertEquals(49.99, formula.calculateNewCowHealth(commonsPlus, uc, 120));
+        assertEquals(49.99, formula.calculateNewCowHealth(commonsPlus, uc, 110));
+        assertEquals(50.01, formula.calculateNewCowHealth(commonsPlus, uc, 100));
+        assertEquals(50.01, formula.calculateNewCowHealth(commonsPlus, uc, 90));
     }
 
     @Test
     void noop_does_nothing() {
         var formula = CowHealthUpdateStrategies.Noop;
 
-        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 110));
-        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 100));
-        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 90));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, uc, 110));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, uc, 100));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, uc, 90));
+    }
+
+    @Test
+    void milan_calculates_correctly() {
+        var formula = CowHealthUpdateStrategies.Milan;
+        assertEquals(62.5, formula.calculateNewCowHealth(commonsPlus1, uc1, 500));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 1000));
+        assertEquals(0.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 2000));
+    }
+
+    @Test
+    void mattanhah_calculates_correctly() {
+        var formula = CowHealthUpdateStrategies.Mattanjah;
+        double tolerance = 1E-12;
+
+        assertEquals(62.5, formula.calculateNewCowHealth(commonsPlus1, uc1, 500));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 1000));
+        assertEquals(0.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 2000));
+
+        assertEquals(100.0, formula.calculateNewCowHealth(commonsPlus2, uc2, 500));
+        assertEquals(62.5, formula.calculateNewCowHealth(commonsPlus2, uc2, 750));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus2, uc2, 1000));
+        assertEquals(37.5, formula.calculateNewCowHealth(commonsPlus2, uc2, 1250));
+        assertEquals(0.0, formula.calculateNewCowHealth(commonsPlus2, uc2, 1500));
+
+        assertEquals(60.125, formula.calculateNewCowHealth(commonsPlus0_5, uc0_5, 100), tolerance);
+        assertEquals(53.125, formula.calculateNewCowHealth(commonsPlus0_5, uc0_5, 500), tolerance);
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus0_5, uc0_5, 1000), tolerance);
+        assertEquals(37.5, formula.calculateNewCowHealth(commonsPlus0_5, uc0_5, 2000), tolerance);
+        assertEquals(0.0, formula.calculateNewCowHealth(commonsPlus0_5, uc0_5, 3000), tolerance);
+
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
@@ -95,11 +95,12 @@ class CowHealthUpdateStrategyTests {
         var formula = CowHealthUpdateStrategies.Milan;
         assertEquals(62.5, formula.calculateNewCowHealth(commonsPlus1, uc1, 500));
         assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 1000));
+        assertEquals(37.5, formula.calculateNewCowHealth(commonsPlus1, uc1, 1500));
         assertEquals(0.0, formula.calculateNewCowHealth(commonsPlus1, uc1, 2000));
     }
 
     @Test
-    void mattanhah_calculates_correctly() {
+    void mattanjah_calculates_correctly() {
         var formula = CowHealthUpdateStrategies.Mattanjah;
         double tolerance = 1E-12;
 


### PR DESCRIPTION
Closes #145 

In this PR, we add two new strategies for Health Update formulas, per emails from Mattanjah de Vries, week of Monday 01/06 through 01/13.

# Details

The two new formulas are called `Milan` (named for Milan de Vries, who wrote the first version of HappyCows), and `Mattanjah` (the professor that designed the HappyCows game.)

The `Milan` formula is as follows:

```
excess =   totalCows - effectiveCapacity
x = (excess / capacity) 
for excess > 0
   adjustment_factor = 1 - x^2
for excess <= 0
   adjustment_factor = 1 + x^2
adjustment_factor = max(0, adjustment_factor)
new_health = old_health * adjustment_factor   
```

The Mattanjah formulas is identical, except that `x = (excess / capacity) * degradationRate`

When degradationRate = 1.0, Milan and Mattanjah are identical, and have the following graph for capacity = 1000:

![image](https://github.com/user-attachments/assets/d338d6a5-5121-4c12-9369-447069938c37)

Here is what the Mattanjah formula looks like for degradationRate = 2.0:

At 2.0, sick cows get healthier much faster than for degradationRate 1.0, and the healthy cows get sick faster, all dying at 1500 instead of 2000 (i.e. twice as fast, if you think of the distance from 1000 to 1500 as half the distance from 1000 to 2000).

![image(1)](https://github.com/user-attachments/assets/e605fd3f-a4ea-4605-81d9-b89d079d801a)

On the other hand, when we cut the degradationRate in half, we have this graph.  Here, the sick cows get healthy more slowly when occupancy is under 1000, and they get sick more slowly also.   It takes twice as many excess cows for all of the cows to die; 1000 is stasis, and 3000 is all cows die, a difference of 2000 instead of 1000.

![image(2)](https://github.com/user-attachments/assets/26d3b4b8-fbb3-486f-9a65-9c18af06cdaa)

