### PR TITLE
Updating the Commons Stats to Meet Java 17

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonStats.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonStats.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
-import java.util.Date;
+import java.time.Instant;
 
 import javax.persistence.*;
 
@@ -26,8 +26,7 @@ public class CommonStats {
     private double avgHealth;
     
     @CreationTimestamp
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "create_date")
-    private Date createDate;
+    private Instant createDate;
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.csv.CSVFormat;
@@ -49,14 +51,15 @@ public class CommonStatsCSVHelper {
     CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format);
 
     csvPrinter.printRecord(headers);
-
+    ZoneId pst = ZoneId.of("America/Los_Angeles");
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(pst);
     for (CommonStats line : stats) {
       List<String> data = Arrays.asList(
           String.valueOf(line.getId()),
           String.valueOf(line.getCommonsId()),
           String.valueOf(line.getNumCows()),
           String.valueOf(line.getAvgHealth()),
-          String.valueOf(line.getCreateDate()));
+          formatter.format(line.getCreateDate()));
       csvPrinter.printRecord(data);
     }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,7 @@ public class CommonStatsControllerTests extends ControllerTestCase {
         .commonsId(17L)
         .numCows(20)
         .avgHealth(10)
+        .createDate(Instant.parse("2004-03-11T08:00:00Z"))
         .build();
 
     CommonStats expectedStats2 = CommonStats
@@ -92,6 +94,7 @@ public class CommonStatsControllerTests extends ControllerTestCase {
         .commonsId(42L)
         .numCows(120)
         .avgHealth(20)
+        .createDate(Instant.parse("2004-03-27T08:00:00Z"))
         .build();
 
     @WithMockUser(roles = { "ADMIN" })
@@ -144,7 +147,7 @@ public class CommonStatsControllerTests extends ControllerTestCase {
 
             String expected = 
                     "id,commonsId,numCows,avgHealth,createDate\r\n" +
-                    "0,17,20,10.0,null\r\n";
+                    "0,17,20,10.0,2004-03-11 00:00:00\r\n";
                                         
             assertEquals(expected, responseString);
     }
@@ -164,8 +167,8 @@ public class CommonStatsControllerTests extends ControllerTestCase {
 
             String expected = 
                     "id,commonsId,numCows,avgHealth,createDate\r\n" +
-                    "0,17,20,10.0,null\r\n" +
-                    "0,42,120,20.0,null\r\n";
+                    "0,17,20,10.0,2004-03-11 00:00:00\r\n" +
+                    "0,42,120,20.0,2004-03-27 00:00:00\r\n";
                                         
             assertEquals(expected, responseString);
     }


### PR DESCRIPTION
In this PR, I updated the ``CommonStatsCSVHelper`` to use an update ``java.time`` api rather than the deprecated `Date` and `Calendar` APIs. The database appears to migrate successfully without any manual intervention, and is currently deployed on https://happycows-qa.dokku-00.cs.ucsb.edu/ Accessing the new CSV stat download should be available, and can be compared to the one from prior to the update that is attached below. New CSV outputs no longer include the 10ths of seconds, as this causes Excel to use an odd time format, and are output in `America/Los_Angeles` time.
[stats00002.csv](https://github.com/user-attachments/files/18448847/stats00002.csv)

Additionally, I updated the `CommonStats` entity file to use the updated standard.
