### PR TITLE
Remove the Github link from the Footer

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,13 +1,12 @@
 import { Container } from "react-bootstrap";
 
-export default function Footer({systemInfo}) {
+export default function Footer() {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
           HappyCows is a project of <a href="https://devries.chem.ucsb.edu/about-5">Mattanjah de Vries</a>, 
-          Distinguished Professor of Chemistry at UC Santa Barbara. 
-          The open source code is <a data-testid="github-href" href={systemInfo?.sourceRepo}>available on GitHub</a>. 
+          Distinguished Professor of Chemistry at UC Santa Barbara.
         </p>
         
       </Container>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -17,7 +17,7 @@ export default function BasicLayout({ children }) {
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>
-      <Footer systemInfo={systemInfo}/>
+      <Footer />
     </div>
   );
 }

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -11,10 +11,7 @@ describe("Footer tests", () => {
         const text = screen.getByTestId("footer-content");
         expect(text).toBeInTheDocument();
         expect(typeof(text.textContent)).toBe('string');
-        expect(text.textContent).toEqual('HappyCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
-    
-        const href = screen.getByTestId("github-href");
-        expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156/proj-happycows");
+        expect(text.textContent).toEqual('HappyCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara.');
     });
 
     test("renders correctly when systemInfo.showingNeither", async () => {
@@ -24,8 +21,5 @@ describe("Footer tests", () => {
 
         const text = screen.getByTestId("footer-content");
         expect(text).toBeInTheDocument();
-            
-        const href = screen.getByTestId("github-href");
-        expect(href.href).toBe("");
     });
 });


### PR DESCRIPTION
In this PR, I remove the Github repo link from the Footer component, modify the associated tests, and the usages.

New Footer:
![image](https://github.com/user-attachments/assets/5b798bec-b76e-4e82-8504-6d01930167f7)


Closes #148 