### PR TITLE
Increasing the Default Chat Page Size to 100

### DIFF
--- a/frontend/src/fixtures/chatMessageFixtures.js
+++ b/frontend/src/fixtures/chatMessageFixtures.js
@@ -165,4 +165,21 @@ export const chatMessageFixtures = {
             "hidden": false
         },
     ],
+    oneHundredMessages:[
+    ]
+}
+
+    chatMessageFixtures.oneHundredMessages=chatMessageFixtures.oneHundredMessages.concat(chatMessageFixtures.twelveChatMessages)
+
+for(let i = 0; i < 90; i++){
+    chatMessageFixtures.oneHundredMessages.push({
+        "id": 13 + i,
+        "userId": 1,
+        "commonsId": 1,
+        "timestamp": "2023-08-24T23:57:46.576+00:00",
+        "message": "More chat testing...",
+        "dm": false,
+        "toUserId": 0,
+        "hidden": false
+    },)
 }

--- a/frontend/src/main/components/Chat/ChatDisplay.js
+++ b/frontend/src/main/components/Chat/ChatDisplay.js
@@ -5,7 +5,7 @@ import { useBackend } from "main/utils/useBackend";
 // Props for storybook manual injection
 
 const ChatDisplay = ({ commonsId }) => {
-    const initialMessagePageSize = 10;
+    const initialMessagePageSize = 100;
     const refreshRate = 2000;
 
     // Stryker disable all

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.js
@@ -89,7 +89,7 @@ describe("ChatDisplay tests", () => {
         expect(axiosMock.history.get.length).toBe(3);
     });
     expect(axiosMock.history.get[0].url).toBe("/api/chat/get");
-    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1, page: 0, size: 10 });
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1, page: 0, size: 100 });
     expect(axiosMock.history.get[1].url).toBe("/api/usercommons/commons/all");
     expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
 
@@ -141,7 +141,7 @@ describe("ChatDisplay tests", () => {
     });
     expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
     expect(axiosMock.history.get[1].url).toBe("/api/chat/get");
-    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1, page: 0, size: 10 });
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1, page: 0, size: 100 });
     expect(axiosMock.history.get[2].url).toBe("/api/usercommons/commons/all");
     expect(axiosMock.history.get[2].params).toEqual({ commonsId: 1 });
 
@@ -155,49 +155,5 @@ describe("ChatDisplay tests", () => {
 
   });
 
-  test("displays cuts off at 10 messages", async () => {
-
-    //arrange
-
-    axiosMock.onGet("/api/chat/get").reply(200, { content: chatMessageFixtures.twelveChatMessages });
-    axiosMock.onGet("/api/usercommons/commons/all").reply(200, userCommonsFixtures.threeUserCommons);
-
-    //act
-    render(
-        <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-                <ChatDisplay commonsId={commonsId} />
-            </MemoryRouter>
-        </QueryClientProvider>
-    );
-    
-    //assert
-    await waitFor(() => {
-        expect(axiosMock.history.get.length).toBe(3);
-    });
-    expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
-    expect(axiosMock.history.get[1].url).toBe("/api/chat/get");
-    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1, page: 0, size: 10 });
-    expect(axiosMock.history.get[2].url).toBe("/api/usercommons/commons/all");
-    expect(axiosMock.history.get[2].params).toEqual({ commonsId: 1 });
-
-    await waitFor(() => {
-        expect(screen.getByTestId("ChatMessageDisplay-11")).toBeInTheDocument();
-        
-    });
-
-    expect(screen.getByTestId("ChatMessageDisplay-12")).toBeInTheDocument();
-    expect(screen.getByTestId("ChatMessageDisplay-3")).toBeInTheDocument();
-
-    expect(screen.queryByTestId("ChatMessageDisplay-1")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("ChatMessageDisplay-2")).not.toBeInTheDocument();
-    
-    expect(screen.queryByText("This should not appear")).not.toBeInTheDocument();
-    expect(screen.queryByText("This should also be cut off")).not.toBeInTheDocument();
-
-    expect(screen.getByText("This should appear, though")).toBeInTheDocument();
-    expect(screen.getByText("This one too!")).toBeInTheDocument();
-
-  });
 
 });

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.js
@@ -159,8 +159,6 @@ describe("ChatDisplay tests", () => {
 
     //arrange
 
-      console.log(chatMessageFixtures.oneHundredMessages);
-
     axiosMock.onGet("/api/chat/get").reply(200, { content: chatMessageFixtures.oneHundredMessages });
     axiosMock.onGet("/api/usercommons/commons/all").reply(200, userCommonsFixtures.threeUserCommons);
 


### PR DESCRIPTION
In this PR, I increase the default page size in the ChatDisplayPanel to 100 from 10 in order to display a greater number of messages. As a result, I remove a test that checks whether it only displays the last 10 messages.

These changes are currently deployed on https://happycows-qa.dokku-00.cs.ucsb.edu/ on Test Commons, which has 100 messages.