### PR TITLE
Allowing the Import of Vite Assets as Modules

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +14,14 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy, HttpServletRequest request) {
     String path = proxy.path("/");
+    String query = "";
+    if (request.getQueryString() != null) {
+      query = "?" + request.getQueryString();
+    }
     try {
-      return proxy.uri("http://localhost:3000/" + path).get();
+      return proxy.uri("http://localhost:3000/" + path + query).get();
     } catch (ResourceAccessException e) {
       if (e.getCause() instanceof ConnectException) {
         String instructions = """


### PR DESCRIPTION
In essence, Vite takes assets like images and json files imported into components and wraps them into being JavaScript modules.

In order to know to do so, Vite appends ?import to the end of the module strings. However, the FrontendProxyController would drop the query string, and as a result Vite would package the assets improperly.
