### PR TITLE
Mac Localhost development fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.3</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
-            <version>4.1.8</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>me.paulschwarz</groupId>
@@ -129,6 +129,12 @@
             <artifactId>commons-csv</artifactId>
             <version>1.10.0</version>
         </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+      </dependency>
+
 
     </dependencies>
 


### PR DESCRIPTION
Other CS156 projects include the use of the `org.apache.httpcomponents.client5:httpclient5` as part of the wiremock server; however since happycows was a prototype and uses an older version, this is not a happycows dependency. The default `RestTemplate` using by Spring Boot will implode upon being asked to upgrade to a WebSocket by Vite. However, the Apache HttpClient5 will just complain and continue forward. As of Spring 3.4, the apache client will be automatically used by Spring Boot if on the classpath, allowing the other projects to simply continue. Explicitly including this in the `pom.xml` should bring consistency to the projects and allow mac users to complete local development of happycows.

Will later file a ticket to migrate wiremock service to consistent version.