### PR TITLE
pc - add field hide to commons with db migrations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -38,6 +38,8 @@ public class Commons {
     private int carryingCapacity;
     private double degradationRate;
 
+    private boolean hide;
+
     // these defaults match old behavior
     @Enumerated(EnumType.STRING)
     @Builder.Default

--- a/src/main/resources/db/migration/changes/Z001_add_hide_to_commons.json
+++ b/src/main/resources/db/migration/changes/Z001_add_hide_to_commons.json
@@ -1,0 +1,41 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Z001_add_hide_to_commons",
+        "author": "pconrad",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "columnExists": {
+                  "tableName": "COMMONS",
+                  "columnName": "HIDE"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "addColumn": {
+              "tableName": "COMMONS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "HIDE",
+                    "type": "BOOLEAN",
+                    "defaultValue": "false"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #206 

In this PR, we add a field called hide to the commons, with a db migration setting the default value to false.

Future PRs will add the ability for admins to toggle this field; If the field is true, the commons cannot be joined or played.
