### PR TITLE
Hidden Commons: Make "hidden" field settable and visible in frontend.

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -28,6 +28,12 @@ export default defineConfig([
       reactRefresh.configs.vite,
       reactPlugin.configs.flat.recommended,
     ],
+    // Add settings to avoid "React version not specified" warning
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -15,10 +15,12 @@ const commonsPlusFixtures = {
         showChat: false,
         capacityPerUser: 50,
         carryingCapacity: 100,
+        hidden: false,
       },
       totalCows: 10,
       totalUsers: 2,
       effectiveCapacity: 100,
+      hidden: false,
     },
     {
       commons: {
@@ -35,6 +37,7 @@ const commonsPlusFixtures = {
         showChat: true,
         capacityPerUser: 5,
         carryingCapacity: 42,
+        hidden: true,
       },
       totalCows: 0,
       totalUsers: 1,
@@ -55,6 +58,7 @@ const commonsPlusFixtures = {
         showChat: true,
         capacityPerUser: 50,
         carryingCapacity: 123,
+        hidden: false,
       },
       totalCows: 0,
       totalUsers: 1,

--- a/frontend/src/main/components/Commons/AdminCommonsCard.jsx
+++ b/frontend/src/main/components/Commons/AdminCommonsCard.jsx
@@ -106,7 +106,17 @@ export default function AdminCommonsCard({ commonItem, currentUser }) {
       >
         <Card.Header style={headerStyle}>
           <Card.Title className="mb-0">
-            {commons.name} (ID: {commons.id})
+            <Row>
+              <Col>
+                {commons.name} (ID: {commons.id})
+              </Col>
+              <Col>
+                <div>
+                  <strong>Hidden:&nbsp;</strong>
+                  {String(commons.hidden)}
+                </div>
+              </Col>
+            </Row>
           </Card.Title>
         </Card.Header>
         <Card.Body style={bodyStyle}>

--- a/frontend/src/main/components/Commons/CommonsForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsForm.jsx
@@ -145,7 +145,19 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-        <Col md={6}>
+        <Col md={2}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="hidden">Hidden</Form.Label>
+            <Form.Check
+              type="switch"
+              id="hidden"
+              data-testid={`${testid}-hidden`}
+              defaultChecked={DefaultVals.hidden}
+              {...register("hidden")}
+            />
+          </Form.Group>
+        </Col>
+        <Col md={4}>
           <Form.Group className="mb-3">
             <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
             <OverlayTrigger

--- a/frontend/src/main/pages/AdminEditCommonsPage.jsx
+++ b/frontend/src/main/pages/AdminEditCommonsPage.jsx
@@ -47,6 +47,7 @@ export default function CommonsEditPage() {
         commons.belowCapacityHealthUpdateStrategy,
       showLeaderboard: commons.showLeaderboard,
       showChat: commons.showChat,
+      hidden: commons.hidden,
     },
   });
 

--- a/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
+++ b/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import commonsFixtures from "fixtures/commonsFixtures";
+import AdminCommonsCard from "main/components/Commons/AdminCommonsCard";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+
+export default {
+  title: "components/Commons/AdminCommonsCard",
+  component: AdminCommonsCard,
+};
+
+const Template = (args) => {
+  return <AdminCommonsCard {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  commonItem: commonsPlusFixtures.threeCommonsPlus[0],
+  currentUser: currentUserFixtures.adminUser,
+};

--- a/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
+++ b/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import commonsFixtures from "fixtures/commonsFixtures";
 import AdminCommonsCard from "main/components/Commons/AdminCommonsCard";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
@@ -78,6 +78,7 @@ describe("AdminCreateCommonsPage tests", () => {
       aboveCapacityHealthUpdateStrategy: "strat2",
       belowCapacityHealthUpdateStrategy: "strat3",
       showLeaderboard: false,
+      hidden: false,
     });
 
     render(
@@ -135,6 +136,7 @@ describe("AdminCreateCommonsPage tests", () => {
 
     const expectedCommons = {
       name: "My New Commons",
+      hidden: false,
       startingBalance: 500,
       cowPrice: 10,
       milkPrice: 5,

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
@@ -66,6 +66,7 @@ describe("AdminEditCommonsPage tests", () => {
         showChat: false,
         aboveCapacityHealthUpdateStrategy: "strat1",
         belowCapacityHealthUpdateStrategy: "strat2",
+        hidden: false,
       });
       axiosMock.onPut("/api/commons/update").reply(200, {
         id: 5,
@@ -82,6 +83,7 @@ describe("AdminEditCommonsPage tests", () => {
         showChat: false,
         aboveCapacityHealthUpdateStrategy: "strat2",
         belowCapacityHealthUpdateStrategy: "strat3",
+        hidden: true,
       });
     });
 
@@ -122,6 +124,7 @@ describe("AdminEditCommonsPage tests", () => {
         screen.getByLabelText(/When below capacity/);
       const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
       const showChatField = screen.getByLabelText(/Show Chat?\?/);
+      const hiddenField = screen.getByLabelText(/Hidden/);
 
       expect(nameField).toHaveValue("Seths Common");
       expect(startingDateField).toHaveValue("2022-03-05");
@@ -136,6 +139,7 @@ describe("AdminEditCommonsPage tests", () => {
       expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
       expect(showLeaderboardField).not.toBeChecked();
       expect(showChatField).not.toBeChecked();
+      expect(hiddenField).not.toBeChecked();
     });
 
     test("Changes when you click Update", async () => {
@@ -164,6 +168,7 @@ describe("AdminEditCommonsPage tests", () => {
         screen.getByLabelText(/When below capacity/);
       const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
       const showChatField = screen.getByLabelText(/Show Chat?\?/);
+      const hiddenField = screen.getByLabelText(/Hidden/);
 
       expect(nameField).toHaveValue("Seths Common");
       expect(startingDateField).toHaveValue("2022-03-05");
@@ -178,6 +183,7 @@ describe("AdminEditCommonsPage tests", () => {
       expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
       expect(showLeaderboardField).not.toBeChecked();
       expect(showChatField).not.toBeChecked();
+      expect(hiddenField).not.toBeChecked();
 
       const submitButton = screen.getByText("Update");
 
@@ -200,6 +206,7 @@ describe("AdminEditCommonsPage tests", () => {
       });
       fireEvent.click(showLeaderboardField);
       fireEvent.click(showChatField);
+      fireEvent.click(hiddenField);
 
       fireEvent.click(submitButton);
 
@@ -226,6 +233,7 @@ describe("AdminEditCommonsPage tests", () => {
           belowCapacityHealthUpdateStrategy: "strat3",
           showLeaderboard: true,
           showChat: true,
+          hidden: true,
         }),
       ); // posted object
     });


### PR DESCRIPTION
Closes #207 

Deployed with PR #217 on https://happycows-qa.dokku-00.cs.ucsb.edu/

In this PR, we give admins a checkbox to set the hidden field on creation or editing of a Commons.

We also expose the value of this field in the new commons card view, and add the new commons card view to the Storybook.

# To test

* Create a commons with the "hidden" field set or unset.
* Use the new card view to see that the commons hidden value is either true or false.
* Use the edit option to change the value (in both directions)