### PR TITLE
pc - update template for gh-pages site

### DIFF
--- a/frontend/docs-index/index.md
+++ b/frontend/docs-index/index.md
@@ -1,3 +1,8 @@
+
+<!-- markdownlint-disable MD033 MD041 -->
+<!-- disabling MD033 allows inline html -->
+<!-- disabling MD041 allows starting with something other than an H1 -->
+
 <style>
 table, th, td {
   border: 1px solid black;
@@ -17,17 +22,14 @@ tbody tr:nth-child(even) {background-color: #f2f2f2;}
 <thead>
 <tr>
 <th colspan="1" style="text-align:center">Backend</th>
-<th colspan="1" style="text-align:center">Frontend</th>
-</tr>
-<tr>
-<th>Javadoc</th>
-<th>Storybook</th>
+<th colspan="2" style="text-align:center">Frontend (Storybook/Chromatic)</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td><a href="javadoc">javadoc</a></td>
-<td><a href="chromatic">chromatic</a></td>
+<td><a href="chromatic">storybook</a></td>
+<td><a href="chromatic/build.html">build info</a></td>
 </tr>
 </tbody>
 </table>
@@ -57,24 +59,24 @@ tbody tr:nth-child(even) {background-color: #f2f2f2;}
 </tbody>
 </table>
 
-
 ## Open Pull Requests
 
-### Documentation
+### Documentation for PRs
 
 <table>
 <thead>
 <tr>
 <th colspan="3" style="text-align:center">Pull Request</th>
 <th colspan="1" style="text-align:center">Backend</th>
-<th colspan="1" style="text-align:center">Frontend</th>
+<th colspan="2" style="text-align:center">Frontend (Storybook/Chromatic)</th>
 </tr>
 <tr>
 <th>PR</th>
 <th>Branch</th>
 <th>Author</th>
 <th>Javadoc</th>
-<th>Chromatic</th>
+<th>storybook</th>
+<th>build info</th>
 </tr>
 </thead>
 <tbody>
@@ -84,13 +86,14 @@ tbody tr:nth-child(even) {background-color: #f2f2f2;}
 <td>{{pr.headRefName}}</td>
 <td>{{pr.author.login}}</td>
 <td><a href="prs/{{pr.number}}/javadoc">javadoc</a></td>
-<td><a href="prs/{{pr.number}}/chromatic">chromatic</a></td>
+<td><a href="prs/{{pr.number}}/chromatic">chromatic sb</a></td>
+<td><a href="prs/{{pr.number}}/chromatic/build.html">build info</a></td>
 </tr>
 {% endfor %}
 </tbody>
 </table>
 
-### Test Coverage
+### Test Coverage for PRs
 
 <table>
 <thead>
@@ -127,12 +130,13 @@ tbody tr:nth-child(even) {background-color: #f2f2f2;}
 ## Notes
 
 If links in the PR tables don't work, note the following:
+
 * Backend links may not be updated for PRs that do not touch the backend code.
 * Frontend links may not be updated for PRs that do not touch the frontend code.
 * If a link doesn't work when you expect that it should, check that the appropriate [Github Actions](https://github.com/{{site.repo}}/actions) workflow completed successfully.
 * You can also check the contents of the [gh-pages branch of this repo](https://github.com/{{site.repo}}/tree/gh-pages) to see if they were updated with the appropriate directory.
 * Note that the pitest runs that are triggered by PRs and by workflow 2 compute
   incremental pitest results based on stored history.  It is rare, but this may
-  occasionally be different from the results when doing a full pitest run from 
+  occasionally be different from the results when doing a full pitest run from
   scratch, which is done every time a push is made to the main branch (for example,
   when merging a PR).


### PR DESCRIPTION
In this PR, we update the template for the Github Pages site.

Before:

<img width="676" height="801" alt="image" src="https://github.com/user-attachments/assets/1dac06ea-c5ef-41d4-9e31-067cbefdf43e" />


After: 

