### PR TITLE
Hidden Commons: Hide hidden commons on PlayPage and HomePage

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -28,6 +28,12 @@ export default defineConfig([
       reactRefresh.configs.vite,
       reactPlugin.configs.flat.recommended,
     ],
+    // Add settings to avoid "React version not specified" warning
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -87,6 +87,26 @@ const commonsPlusFixtures = {
       effectiveCapacity: 23,
     },
   ],
+  commonsPlusShowLeaderboardTrue: {
+    commons: {
+      id: 5,
+      name: "Test2",
+      cowPrice: 10.0,
+      milkPrice: 1.0,
+      startingBalance: 100.0,
+      startingDate: "2022-11-11T00:00:00",
+      lastDate: "2022-11-11T00:00:00",
+      endingDate: null,
+      degradationRate: 3.0,
+      showLeaderboard: true,
+      showChat: true,
+      capacityPerUser: 1,
+      carryingCapacity: 23,
+    },
+    totalCows: 0,
+    totalUsers: 0,
+    effectiveCapacity: 23,
+  },
 };
 
 export default commonsPlusFixtures;

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -15,10 +15,12 @@ const commonsPlusFixtures = {
         showChat: false,
         capacityPerUser: 50,
         carryingCapacity: 100,
+        hidden: false,
       },
       totalCows: 10,
       totalUsers: 2,
       effectiveCapacity: 100,
+      hidden: false,
     },
     {
       commons: {
@@ -35,6 +37,7 @@ const commonsPlusFixtures = {
         showChat: true,
         capacityPerUser: 5,
         carryingCapacity: 42,
+        hidden: true,
       },
       totalCows: 0,
       totalUsers: 1,
@@ -55,6 +58,7 @@ const commonsPlusFixtures = {
         showChat: true,
         capacityPerUser: 50,
         carryingCapacity: 123,
+        hidden: false,
       },
       totalCows: 0,
       totalUsers: 1,

--- a/frontend/src/main/components/Commons/AdminCommonsCard.jsx
+++ b/frontend/src/main/components/Commons/AdminCommonsCard.jsx
@@ -106,7 +106,17 @@ export default function AdminCommonsCard({ commonItem, currentUser }) {
       >
         <Card.Header style={headerStyle}>
           <Card.Title className="mb-0">
-            {commons.name} (ID: {commons.id})
+            <Row>
+              <Col>
+                {commons.name} (ID: {commons.id})
+              </Col>
+              <Col>
+                <div>
+                  <strong>Hidden:&nbsp;</strong>
+                  {String(commons.hidden)}
+                </div>
+              </Col>
+            </Row>
           </Card.Title>
         </Card.Header>
         <Card.Body style={bodyStyle}>

--- a/frontend/src/main/components/Commons/CommonsForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsForm.jsx
@@ -145,7 +145,19 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-        <Col md={6}>
+        <Col md={2}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="hidden">Hidden</Form.Label>
+            <Form.Check
+              type="switch"
+              id="hidden"
+              data-testid={`${testid}-hidden`}
+              defaultChecked={DefaultVals.hidden}
+              {...register("hidden")}
+            />
+          </Form.Group>
+        </Col>
+        <Col md={4}>
           <Form.Group className="mb-3">
             <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
             <OverlayTrigger

--- a/frontend/src/main/components/Commons/ManageCows.jsx
+++ b/frontend/src/main/components/Commons/ManageCows.jsx
@@ -14,7 +14,7 @@ const ManageCows = ({ userCommons, commons, setMessage, openModal }) => {
 
   // Stryker restore all
   return (
-    <Card>
+    <Card data-testid="ManageCows">
       <Card.Header as="h5" className="woodenboardtable">
         Manage Cows
       </Card.Header>

--- a/frontend/src/main/pages/AdminEditCommonsPage.jsx
+++ b/frontend/src/main/pages/AdminEditCommonsPage.jsx
@@ -47,6 +47,7 @@ export default function CommonsEditPage() {
         commons.belowCapacityHealthUpdateStrategy,
       showLeaderboard: commons.showLeaderboard,
       showChat: commons.showChat,
+      hidden: commons.hidden,
     },
   });
 

--- a/frontend/src/main/pages/HomePage.jsx
+++ b/frontend/src/main/pages/HomePage.jsx
@@ -6,7 +6,10 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsList from "main/components/Commons/CommonsList";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
-import { commonsNotJoined } from "main/utils/commonsUtils";
+import {
+  filterCommonsJoinedAndNotHidden,
+  filterCommonsNotJoinedAndNotHidden,
+} from "main/utils/commonsUtils";
 import getBackgroundImage from "main/components/Utils/HomePageBackground";
 
 import "./HomePage.css";
@@ -41,9 +44,11 @@ export default function HomePage({ hour = null }) {
   // Stryker disable all : TODO: restructure this code to avoid the need for this disable
   useEffect(() => {
     if (currentUser?.root?.user?.commons) {
-      setCommonsJoined(currentUser.root.user.commons);
+      setCommonsJoined(
+        filterCommonsJoinedAndNotHidden(commons, currentUser.root.user.commons),
+      );
     }
-  }, [currentUser]);
+  }, [commons, currentUser]);
 
   const firstName = currentUser?.root?.user?.givenName || "";
   const time = hour === null ? new Date().getHours() : hour;
@@ -57,7 +62,10 @@ export default function HomePage({ hour = null }) {
   };
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
-  const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
+  const commonsNotJoinedList = filterCommonsNotJoinedAndNotHidden(
+    commons,
+    commonsJoined,
+  );
 
   return (
     <div

--- a/frontend/src/main/pages/PlayPage.jsx
+++ b/frontend/src/main/pages/PlayPage.jsx
@@ -65,8 +65,9 @@ export default function PlayPage() {
     matched = commonsforuser.some((com) => com.id === commonsPlus.commons.id);
   }
 
-  const allowed = commonsPlusExists && matched;
+  const allowed = commonsPlusExists && matched && !commonsPlus.commons.hidden;
   const notallowed = commonsPlusExists && !matched;
+  const hidden = commonsPlusExists && commonsPlus.commons.hidden;
 
   // Stryker disable all
   const { data: userCommonsProfits } = useBackend(
@@ -174,18 +175,21 @@ export default function PlayPage() {
         <Container>
           {!commonsPlus && <h1>This commons does not exist!</h1>}
           {notallowed && <h1>You have yet to join this commons!</h1>}
+          {hidden && (
+            <h1>This commons has been hidden by the site administrator.</h1>
+          )}
           {allowed && !!currentUser && (
             <CommonsPlay currentUser={currentUser} />
           )}
 
-          {!!commonsPlus && (
+          {allowed && !!commonsPlus && (
             <CommonsOverview
               commonsPlus={commonsPlus}
               currentUser={currentUser}
             />
           )}
           <br />
-          {!!userCommons && !!commonsPlus && (
+          {allowed && !!userCommons && !!commonsPlus && (
             <CardGroup>
               <ManageCows
                 userCommons={userCommons}
@@ -210,7 +214,7 @@ export default function PlayPage() {
         </Container>
       </BasicLayout>
       {(hasRole(currentUser, "ROLE_ADMIN") ||
-        (!!commonsPlus && commonsPlus.commons.showChat)) && (
+        (allowed && !!commonsPlus && commonsPlus.commons.showChat)) && (
         <div style={chatContainerStyle} data-testid="playpage-chat-div">
           {!!isChatOpen && <ChatPanel commonsId={commonsId} />}
           <Button

--- a/frontend/src/main/utils/commonsUtils.js
+++ b/frontend/src/main/utils/commonsUtils.js
@@ -15,7 +15,12 @@ export function cellToAxiosParamsDelete(cell) {
   };
 }
 
-export function commonsNotJoined(commons, commonsJoined) {
+export function filterCommonsNotJoinedAndNotHidden(commons, commonsJoined) {
   const joinedIdList = commonsJoined.map((c) => c.id);
-  return commons.filter((f) => !joinedIdList.includes(f.id));
+  return commons.filter((f) => !f.hidden && !joinedIdList.includes(f.id));
+}
+
+export function filterCommonsJoinedAndNotHidden(commons, commonsJoined) {
+  const joinedIdList = commonsJoined.map((c) => c.id);
+  return commons.filter((f) => !f.hidden && joinedIdList.includes(f.id));
 }

--- a/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
+++ b/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import commonsFixtures from "fixtures/commonsFixtures";
+import AdminCommonsCard from "main/components/Commons/AdminCommonsCard";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+
+export default {
+  title: "components/Commons/AdminCommonsCard",
+  component: AdminCommonsCard,
+};
+
+const Template = (args) => {
+  return <AdminCommonsCard {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  commonItem: commonsPlusFixtures.threeCommonsPlus[0],
+  currentUser: currentUserFixtures.adminUser,
+};

--- a/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
+++ b/frontend/src/stories/components/Commons/AdminCommonsCard.stories.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import commonsFixtures from "fixtures/commonsFixtures";
 import AdminCommonsCard from "main/components/Commons/AdminCommonsCard";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.jsx
@@ -4,12 +4,9 @@ import { MemoryRouter } from "react-router";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import CommonsOverview from "main/components/Commons/CommonsOverview";
-import PlayPage from "main/pages/PlayPage";
-import commonsFixtures from "fixtures/commonsFixtures";
-import leaderboardFixtures from "fixtures/leaderboardFixtures";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import { vi } from "vitest";
 
 const mockNavigate = vi.fn();
@@ -21,10 +18,10 @@ vi.mock("react-router", async () => ({
   useNavigate: () => mockNavigate,
 }));
 
-describe("CommonsOverview tests", () => {
-  const queryClient = new QueryClient();
-  const axiosMock = new AxiosMockAdapter(axios);
+const queryClient = new QueryClient();
+const axiosMock = new AxiosMockAdapter(axios);
 
+describe("CommonsOverview tests", () => {
   beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
@@ -33,72 +30,54 @@ describe("CommonsOverview tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   });
 
-  test("renders without crashing", () => {
-    render(
-      <CommonsOverview commonsPlus={commonsPlusFixtures.oneCommonsPlus[0]} />,
-    );
-  });
-
   test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {
-    apiCurrentUserFixtures.adminUser.user.commons[0] =
-      commonsFixtures.oneCommons;
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.adminUser);
-    axiosMock
-      .onGet("/api/commons/plus", { params: { id: 1 } })
-      .reply(200, commonsPlusFixtures.oneCommonsPlus[0]);
-    axiosMock
-      .onGet("/api/leaderboard/all")
-      .reply(200, leaderboardFixtures.threeUserCommonsLB);
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <PlayPage />
+          <CommonsOverview
+            commonsPlus={commonsPlusFixtures.oneCommonsPlus[0]}
+            currentUser={currentUserFixtures.adminUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toEqual(5);
-    });
     expect(
       await screen.findByTestId("user-leaderboard-button"),
     ).toBeInTheDocument();
     const leaderboardButton = screen.getByTestId("user-leaderboard-button");
     fireEvent.click(leaderboardButton);
-    //expect(mockNavigate).toBeCalledWith({ "to": "/leaderboard/1" });
+    expect(mockNavigate).toHaveBeenCalledWith("/leaderboard/4");
   });
 
-  test("No LeaderboardPage for an ordinary user when commons has showLeaderboard = false", async () => {
-    const ourCommons = {
-      ...commonsFixtures.oneCommons,
-      showLeaderboard: false,
-    };
-    const ourCommonsPlus = {
-      ...commonsPlusFixtures.oneCommonsPlus,
-      commons: ourCommons,
-    };
-    apiCurrentUserFixtures.userOnly.user.commonsPlus =
-      commonsPlusFixtures.oneCommonsPlus[0];
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/commons/plus", { params: { id: 1 } })
-      .reply(200, ourCommonsPlus);
-    axiosMock
-      .onGet("/api/leaderboard/all")
-      .reply(200, leaderboardFixtures.threeUserCommonsLB);
+  test("LeaderboardPage for an ordinary user when commons has showLeaderboard = true", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <PlayPage />
+          <CommonsOverview
+            commonsPlus={commonsPlusFixtures.commonsPlusShowLeaderboardTrue}
+            currentUser={currentUserFixtures.userOnly}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toEqual(3);
-    });
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("user-leaderboard-button"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  test("No LeaderboardPage for an ordinary user when commons has showLeaderboard = false", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsOverview
+            commonsPlus={commonsPlusFixtures.oneCommonsPlus[0]}
+            currentUser={currentUserFixtures.userOnly}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
     await waitFor(() =>
       expect(
         screen.queryByTestId("user-leaderboard-button"),

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
@@ -78,6 +78,7 @@ describe("AdminCreateCommonsPage tests", () => {
       aboveCapacityHealthUpdateStrategy: "strat2",
       belowCapacityHealthUpdateStrategy: "strat3",
       showLeaderboard: false,
+      hidden: false,
     });
 
     render(
@@ -135,6 +136,7 @@ describe("AdminCreateCommonsPage tests", () => {
 
     const expectedCommons = {
       name: "My New Commons",
+      hidden: false,
       startingBalance: 500,
       cowPrice: 10,
       milkPrice: 5,

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
@@ -66,6 +66,7 @@ describe("AdminEditCommonsPage tests", () => {
         showChat: false,
         aboveCapacityHealthUpdateStrategy: "strat1",
         belowCapacityHealthUpdateStrategy: "strat2",
+        hidden: false,
       });
       axiosMock.onPut("/api/commons/update").reply(200, {
         id: 5,
@@ -82,6 +83,7 @@ describe("AdminEditCommonsPage tests", () => {
         showChat: false,
         aboveCapacityHealthUpdateStrategy: "strat2",
         belowCapacityHealthUpdateStrategy: "strat3",
+        hidden: true,
       });
     });
 
@@ -122,6 +124,7 @@ describe("AdminEditCommonsPage tests", () => {
         screen.getByLabelText(/When below capacity/);
       const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
       const showChatField = screen.getByLabelText(/Show Chat?\?/);
+      const hiddenField = screen.getByLabelText(/Hidden/);
 
       expect(nameField).toHaveValue("Seths Common");
       expect(startingDateField).toHaveValue("2022-03-05");
@@ -136,6 +139,7 @@ describe("AdminEditCommonsPage tests", () => {
       expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
       expect(showLeaderboardField).not.toBeChecked();
       expect(showChatField).not.toBeChecked();
+      expect(hiddenField).not.toBeChecked();
     });
 
     test("Changes when you click Update", async () => {
@@ -164,6 +168,7 @@ describe("AdminEditCommonsPage tests", () => {
         screen.getByLabelText(/When below capacity/);
       const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
       const showChatField = screen.getByLabelText(/Show Chat?\?/);
+      const hiddenField = screen.getByLabelText(/Hidden/);
 
       expect(nameField).toHaveValue("Seths Common");
       expect(startingDateField).toHaveValue("2022-03-05");
@@ -178,6 +183,7 @@ describe("AdminEditCommonsPage tests", () => {
       expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
       expect(showLeaderboardField).not.toBeChecked();
       expect(showChatField).not.toBeChecked();
+      expect(hiddenField).not.toBeChecked();
 
       const submitButton = screen.getByText("Update");
 
@@ -200,6 +206,7 @@ describe("AdminEditCommonsPage tests", () => {
       });
       fireEvent.click(showLeaderboardField);
       fireEvent.click(showChatField);
+      fireEvent.click(hiddenField);
 
       fireEvent.click(submitButton);
 
@@ -226,6 +233,7 @@ describe("AdminEditCommonsPage tests", () => {
           belowCapacityHealthUpdateStrategy: "strat3",
           showLeaderboard: true,
           showChat: true,
+          hidden: true,
         }),
       ); // posted object
     });

--- a/frontend/src/tests/pages/PlayPage.test.jsx
+++ b/frontend/src/tests/pages/PlayPage.test.jsx
@@ -56,6 +56,7 @@ describe("PlayPage tests", () => {
       {
         id: 1,
         name: "Sample Commons",
+        hidden: false,
       },
     ]);
     axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
@@ -63,6 +64,7 @@ describe("PlayPage tests", () => {
         id: 1,
         name: "Sample Commons",
         showChat: true,
+        hidden: false,
       },
       totalPlayers: 5,
       totalCows: 5,
@@ -80,6 +82,67 @@ describe("PlayPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
+    await waitFor(() => {
+      expect(screen.getByTestId("commonsPlay-title")).toBeInTheDocument();
+    });
+
+    for (const testId of [
+      "CommonsOverview",
+      "ManageCows",
+      "playpage-chat-div",
+    ]) {
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    }
+    expect(
+      screen.queryByText(
+        "This commons has been hidden by the site administrator.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("cannot join hidden commons", async () => {
+    axiosMock.onGet("/api/commons/all").reply(200, [
+      {
+        id: 1,
+        name: "Sample Commons",
+        hidden: true,
+      },
+    ]);
+    axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+      commons: {
+        id: 1,
+        name: "Sample Commons",
+        showChat: true,
+        hidden: true,
+      },
+      totalPlayers: 5,
+      totalCows: 5,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PlayPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "This commons has been hidden by the site administrator.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    for (const testId of [
+      "commonsPlay-title",
+      "CommonsOverview",
+      "ManageCows",
+      "playpage-chat-div",
+    ]) {
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+    }
   });
 
   test("click buy button", async () => {

--- a/frontend/src/tests/utils/commonsUtils.test.jsx
+++ b/frontend/src/tests/utils/commonsUtils.test.jsx
@@ -3,7 +3,7 @@ import commonsFixtures from "fixtures/commonsFixtures";
 import { vi } from "vitest";
 import {
   cellToAxiosParamsDelete,
-  commonsNotJoined,
+  filterCommonsNotJoinedAndNotHidden,
   onDeleteSuccess,
 } from "main/utils/commonsUtils";
 
@@ -52,7 +52,7 @@ describe("CommonsUtils", () => {
     });
   });
 
-  describe("commonsNotJoined", () => {
+  describe("filterCommonsNotJoinedAndNotHidden", () => {
     test("it computes the correct result", () => {
       // arrange
       const allCommons = commonsFixtures.sevenCommons;
@@ -65,7 +65,10 @@ describe("CommonsUtils", () => {
       ];
 
       // act
-      const result = commonsNotJoined(allCommons, commonsJoined);
+      const result = filterCommonsNotJoinedAndNotHidden(
+        allCommons,
+        commonsJoined,
+      );
 
       // assert
       expect(result).toEqual(expectedCommonsNotJoined);


### PR DESCRIPTION
Merge after #213  (contains changes from that branch).

Deployed with PR 213 on https://happycows-qa.dokku-00.cs.ucsb.edu/

Closes #209 
Closes #210 

In this PR, we:

* make it so that if a commons is hidden, the PlayPage shows only a message that the commons is hidden.
* remove commons that are hidden from those that can be joined
* remove commons that are hidden from those that can be visited.