### PR TITLE
pc - refactor Developer page and hide swagger link on prod (except on Developer Page) by default

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,3 +58,8 @@ code {
   background-color: rgb(54, 124, 57);
   /* New background color on hover */
 }
+
+.expand-icon {
+  color: rgb(110, 110, 110);
+  font-size: 10px;
+}

--- a/frontend/src/main/pages/DeveloperPage.jsx
+++ b/frontend/src/main/pages/DeveloperPage.jsx
@@ -3,12 +3,48 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { Inspector } from "react-inspector";
 import { useSystemInfo } from "main/utils/systemInfo";
 
+import Table from "react-bootstrap/Table";
+
 const DeveloperPage = () => {
   const { data: systemInfo } = useSystemInfo();
   return (
     <BasicLayout>
-      <h2>Github Branch Information</h2>
-      <p>The following SystemInfo is displayed in a JSON file.</p>
+      <h1>Developer Information</h1>
+      <h2>Current Deployed Branch</h2>
+      <Table striped bordered hover>
+        <tbody>
+          <tr>
+            <td>Github Repo:</td>
+            <td>
+              <a href={systemInfo.sourceRepo}>{systemInfo.sourceRepo}</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Commit Link:</td>
+            <td>
+              <a href={systemInfo.githubUrl}>{systemInfo.githubUrl}</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Commit Hash:</td>
+            <td>{systemInfo.commitId}</td>
+          </tr>
+          <tr>
+            <td>Commit Message:</td>
+            <td>{systemInfo.commitMessage}</td>
+          </tr>
+        </tbody>
+      </Table>
+      <h2>Backend Endpoints</h2>
+      <ul>
+        <li>
+          <a href="/swagger-ui/index.html">Swagger</a>
+        </li>
+      </ul>
+      <h2>System Info</h2>
+      <p>
+        Click <span className="expand-icon">▶</span> character below to expand
+      </p>
       <Inspector data={systemInfo} />
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/DeveloperPage.test.jsx
+++ b/frontend/src/tests/pages/DeveloperPage.test.jsx
@@ -33,7 +33,7 @@ describe("DeveloperPage tests", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
   });
 
-  test("renders branch information text and forwards system info to Inspector", async () => {
+  test("Developer Page has expected info", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -43,10 +43,7 @@ describe("DeveloperPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Github Branch Information"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("The following SystemInfo is displayed in a JSON file."),
+      await screen.findByText("Developer Information"),
     ).toBeInTheDocument();
 
     const inspectorDiv = await screen.findByTestId("mock-inspector");
@@ -59,5 +56,9 @@ describe("DeveloperPage tests", () => {
     await waitFor(() => expect(mockInspector).toHaveBeenCalled());
     const inspectorProps = mockInspector.mock.calls.at(-1)[0];
     expect(inspectorProps.data).toEqual(systemInfoFixtures.showingAll);
+
+    // Check for the presence of the expand icon
+    expect(await screen.findByText("▶")).toBeInTheDocument();
+    expect(await screen.findByText("▶")).toHaveClass("expand-icon");
   });
 });

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -5,7 +5,7 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 
-app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 springdoc.swagger-ui.tryItOutEnabled=true
 springdoc.swagger-ui.csrf.enabled=true


### PR DESCRIPTION
Closes #220 

Deployed on:  https://happycows-dev-pconrad.dokku-00.cs.ucsb.edu/

Before this PR, the Swagger link was shown on the app nav bar by default.

We should not show this by default.

But it is handy to have on the Developer Page which is shown whenever an admin is logged in.

In addition, we refactor the Developer Page to be more informative and user friendly.

## Test plan

1) Visit https://happycows-dev-pconrad.dokku-00.cs.ucsb.edu/ and see swagger link gone.
2) Log in as an admin, and see new Developer page

# Screenshots

Before:

<img width="780" height="397" alt="image" src="https://github.com/user-attachments/assets/0b577e50-d81f-40a1-89c5-182453461892" />

<img width="929" height="334" alt="image" src="https://github.com/user-attachments/assets/582b3045-a43d-4d83-b610-2574b6fb3b44" />

After:

<img width="848" height="455" alt="image" src="https://github.com/user-attachments/assets/ac693b52-0a72-425a-81bf-095321663590" />

<img width="1227" height="641" alt="image" src="https://github.com/user-attachments/assets/cbefa349-bfac-48d9-b5a2-f32280f2637a" />


