### PR TITLE
Adding a Schema Validation Workflow

### DIFF
--- a/.github/workflows/18-validate-db-schema.yml
+++ b/.github/workflows/18-validate-db-schema.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: "18-validate-db-schema: Ensure Migration File Matches Entity Files"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/18-validate-db-schema.yml]
+  push:
+    branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/18-validate-db-schema.yml]
+
+jobs:
+  call-validate-db-schema:
+    uses: ucsb-cs156/workflows/.github/workflows/18-validate-db-schema.yml@main
+    with:
+      JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+
+  


### PR DESCRIPTION
In this PR, I add a schema validation workflow that is directly copied from s26 team02.

This allows us to ensure that liquibase migrations are accurate prior to being added to the app.

Deployed to: https://happycows-qa.dokku-00.cs.ucsb.edu/

NOTE: the deployment action currently references the old deploy script in s25, I can update that in a separate PR.
