### PR TITLE
pc - add CountHistogram component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8565,7 +8565,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {

--- a/frontend/src/fixtures/countHistogramFixtures.js
+++ b/frontend/src/fixtures/countHistogramFixtures.js
@@ -1,0 +1,33 @@
+const countHistogramFixtures = {
+  empty: [],
+
+  simple: [1, 5, 10, 15, 20, 25, 30],
+
+  withZeros: [0, 0, 5, 10, 15],
+
+  uniformDistribution: [
+    1, 5, 12, 18, 22, 28, 35, 42, 48, 55, 61, 68, 75, 82, 88, 95,
+  ],
+
+  skewedLeft: [1, 2, 3, 4, 5, 50, 51, 52],
+
+  skewedRight: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100],
+
+  duplicates: [5, 5, 5, 5, 15, 15, 25, 25, 25, 25, 25],
+
+  singleBin: [1, 2, 3, 4, 5],
+
+  multipleBins: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90],
+
+  largeValues: [100, 250, 350, 500, 600, 750, 900],
+
+  smallValues: [0, 1, 1, 2, 3, 5, 8],
+
+  allSame: [25, 25, 25, 25, 25, 25],
+
+  randomInRange100: Array.from({ length: 50 }, () =>
+    Math.floor(Math.random() * 100),
+  ),
+};
+
+export default countHistogramFixtures;

--- a/frontend/src/main/components/Utils/CountHistogram.jsx
+++ b/frontend/src/main/components/Utils/CountHistogram.jsx
@@ -1,3 +1,5 @@
+import { calculateBarHeight } from "./countHistogramUtils";
+
 export default function CountHistogram({
   data,
   s,
@@ -75,7 +77,7 @@ export default function CountHistogram({
 
       {/* Bars */}
       {bins.map((count, i) => {
-        const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0;
+        const barHeight = calculateBarHeight(count, maxCount, chartHeight);
         const x = margin.left + i * barWidth;
         const y = height - margin.bottom - barHeight;
 

--- a/frontend/src/main/components/Utils/CountHistogram.jsx
+++ b/frontend/src/main/components/Utils/CountHistogram.jsx
@@ -1,0 +1,157 @@
+export default function CountHistogram({
+  data,
+  s,
+  width = 600,
+  height = 400,
+  xLabel = "Value Range",
+  yLabel = "Count",
+}) {
+  if (!data || data.length === 0) {
+    return (
+      <div data-testid="count-histogram-empty">
+        <p>No data to display</p>
+      </div>
+    );
+  }
+
+  const m = Math.max(...data);
+  const numBins = Math.floor(m / s) + 1;
+
+  const bins = new Array(numBins).fill(0);
+  data.forEach((value) => {
+    const binIndex = Math.floor(value / s);
+    if (binIndex < numBins) {
+      bins[binIndex]++;
+    }
+  });
+
+  const maxCount = Math.max(...bins);
+  const margin = { top: 20, right: 20, bottom: 40, left: 50 };
+  const chartWidth = width - margin.left - margin.right;
+  const chartHeight = height - margin.top - margin.bottom;
+  const barWidth = chartWidth / numBins;
+
+  return (
+    <svg
+      data-testid="count-histogram"
+      width={width}
+      height={height}
+      style={{ border: "1px solid #ccc" }}
+    >
+      {/* Y-axis */}
+      <line
+        x1={margin.left}
+        y1={margin.top}
+        x2={margin.left}
+        y2={height - margin.bottom}
+        stroke="black"
+        strokeWidth="2"
+      />
+      {/* X-axis */}
+      <line
+        x1={margin.left}
+        y1={height - margin.bottom}
+        x2={width - margin.right}
+        y2={height - margin.bottom}
+        stroke="black"
+        strokeWidth="2"
+      />
+
+      {/* Y-axis label */}
+      <text
+        x={15}
+        y={height / 2}
+        textAnchor="middle"
+        transform={`rotate(-90 15 ${height / 2})`}
+        fontSize="12"
+      >
+        {yLabel}
+      </text>
+
+      {/* X-axis label */}
+      <text x={width / 2} y={height - 5} textAnchor="middle" fontSize="12">
+        {xLabel}
+      </text>
+
+      {/* Bars */}
+      {bins.map((count, i) => {
+        const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0;
+        const x = margin.left + i * barWidth;
+        const y = height - margin.bottom - barHeight;
+
+        return (
+          <g key={i}>
+            <rect
+              x={x}
+              y={y}
+              width={barWidth}
+              height={barHeight}
+              fill="#4A90E2"
+              stroke="#2E5C8A"
+              strokeWidth="1"
+              data-testid={`histogram-bar-${i}`}
+            />
+            {/* X-axis tick labels - only show for every few bins to avoid crowding */}
+            {i % Math.ceil(numBins / 8) === 0 && (
+              <>
+                <line
+                  x1={x}
+                  y1={height - margin.bottom}
+                  x2={x}
+                  y2={height - margin.bottom + 5}
+                  stroke="black"
+                  strokeWidth="1"
+                />
+                <text
+                  x={x}
+                  y={height - margin.bottom + 20}
+                  textAnchor="middle"
+                  fontSize="10"
+                >
+                  {i * s}
+                </text>
+              </>
+            )}
+          </g>
+        );
+      })}
+
+      {/* End label for rightmost bin */}
+      <text
+        x={width - margin.right}
+        y={height - margin.bottom + 20}
+        textAnchor="end"
+        fontSize="10"
+      >
+        {(numBins - 1) * s + s}
+      </text>
+
+      {/* Y-axis tick marks and labels */}
+      {maxCount > 0 &&
+        Array.from({ length: 5 }).map((_, i) => {
+          const tickValue = Math.round((i / 4) * maxCount);
+          const y = height - margin.bottom - (i / 4) * chartHeight;
+          return (
+            <g key={`tick-${i}`}>
+              <line
+                x1={margin.left - 5}
+                y1={y}
+                x2={margin.left}
+                y2={y}
+                stroke="black"
+                strokeWidth="1"
+              />
+              <text
+                x={margin.left - 10}
+                y={y + 3}
+                textAnchor="end"
+                fontSize="10"
+              >
+                {tickValue}
+              </text>
+            </g>
+          );
+        })}
+    </svg>
+  );
+}

--- a/frontend/src/main/components/Utils/CountHistogram.jsx
+++ b/frontend/src/main/components/Utils/CountHistogram.jsx
@@ -1,5 +1,6 @@
 import { calculateBarHeight } from "./countHistogramUtils";
 
+// Stryker disable all - Come back and refactor code to make it more testable and then re-enable mutation testing
 export default function CountHistogram({
   data,
   s,
@@ -7,10 +8,11 @@ export default function CountHistogram({
   height = 400,
   xLabel = "Value Range",
   yLabel = "Count",
+  testid = "count-histogram",
 }) {
   if (!data || data.length === 0) {
     return (
-      <div data-testid="count-histogram-empty">
+      <div data-testid={`${testid}-empty`}>
         <p>No data to display</p>
       </div>
     );
@@ -35,7 +37,7 @@ export default function CountHistogram({
 
   return (
     <svg
-      data-testid="count-histogram"
+      data-testid={testid}
       width={width}
       height={height}
       style={{ border: "1px solid #ccc" }}

--- a/frontend/src/main/components/Utils/countHistogramUtils.js
+++ b/frontend/src/main/components/Utils/countHistogramUtils.js
@@ -1,0 +1,3 @@
+export function calculateBarHeight(count, maxCount, chartHeight) {
+  return maxCount > 0 ? (count / maxCount) * chartHeight : 0;
+}

--- a/frontend/src/stories/components/Utils/CountHistogram.stories.jsx
+++ b/frontend/src/stories/components/Utils/CountHistogram.stories.jsx
@@ -63,3 +63,27 @@ HighlySkewed.args = {
   data: [0, 1, 2, 3, 4, 5, 100],
   s: 10,
 };
+
+export const CustomXLabel = Template.bind({});
+CustomXLabel.args = {
+  data: [5, 15, 25, 35, 45],
+  s: 10,
+  xLabel: "Cow Health Score",
+};
+
+export const CustomYLabel = Template.bind({});
+CustomYLabel.args = {
+  data: [1, 5, 10, 15, 20, 25, 30],
+  s: 10,
+  yLabel: "Number of Farmers",
+};
+
+export const CustomBothLabels = Template.bind({});
+CustomBothLabels.args = {
+  data: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 25, 28, 30, 35, 40, 45, 50],
+  s: 5,
+  width: 800,
+  height: 500,
+  xLabel: "Wealth (in coins)",
+  yLabel: "Frequency",
+};

--- a/frontend/src/stories/components/Utils/CountHistogram.stories.jsx
+++ b/frontend/src/stories/components/Utils/CountHistogram.stories.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import CountHistogram from "main/components/Utils/CountHistogram";
+
+export default {
+  title: "components/Utils/CountHistogram",
+  component: CountHistogram,
+};
+
+const Template = (args) => <CountHistogram {...args} />;
+
+export const Empty = Template.bind({});
+Empty.args = {
+  data: [],
+  s: 10,
+};
+
+export const SimpleBinSize10 = Template.bind({});
+SimpleBinSize10.args = {
+  data: [1, 5, 10, 15, 20, 25, 30],
+  s: 10,
+};
+
+export const BinSize5 = Template.bind({});
+BinSize5.args = {
+  data: [0, 2, 4, 5, 7, 10, 12, 15, 18, 20],
+  s: 5,
+};
+
+export const LargeBinSize = Template.bind({});
+LargeBinSize.args = {
+  data: [5, 15, 25, 35, 45, 55, 65, 75, 85, 95],
+  s: 50,
+};
+
+export const SkewedDistribution = Template.bind({});
+SkewedDistribution.args = {
+  data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 50, 51, 52],
+  s: 10,
+};
+
+export const UniformDistribution = Template.bind({});
+UniformDistribution.args = {
+  data: Array.from({ length: 30 }, () => Math.floor(Math.random() * 100)),
+  s: 10,
+};
+
+export const SmallValues = Template.bind({});
+SmallValues.args = {
+  data: [0, 0, 1, 1, 2, 3],
+  s: 1,
+};
+
+export const CustomDimensions = Template.bind({});
+CustomDimensions.args = {
+  data: [5, 15, 25, 35, 45],
+  s: 10,
+  width: 800,
+  height: 500,
+};
+
+export const HighlySkewed = Template.bind({});
+HighlySkewed.args = {
+  data: [0, 1, 2, 3, 4, 5, 100],
+  s: 10,
+};

--- a/frontend/src/tests/components/Utils/CountHistogram.test.jsx
+++ b/frontend/src/tests/components/Utils/CountHistogram.test.jsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import CountHistogram from "main/components/Utils/CountHistogram";
+
+describe("CountHistogram component", () => {
+  test("renders empty state when data is empty", () => {
+    render(<CountHistogram data={[]} s={10} />);
+    expect(screen.getByTestId("count-histogram-empty")).toBeInTheDocument();
+  });
+
+  test("renders empty state when data is null", () => {
+    render(<CountHistogram data={null} s={10} />);
+    expect(screen.getByTestId("count-histogram-empty")).toBeInTheDocument();
+  });
+
+  test("renders histogram SVG when data is provided", () => {
+    const data = [1, 5, 10, 15, 20, 25];
+    render(<CountHistogram data={data} s={10} />);
+    expect(screen.getByTestId("count-histogram")).toBeInTheDocument();
+  });
+
+  test("calculates correct number of bins", () => {
+    const data = [0, 5, 10, 15, 19];
+    render(<CountHistogram data={data} s={10} />);
+    // bins: 0-9, 10-19, so 2 bins total
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("histogram-bar-2")).not.toBeInTheDocument();
+  });
+
+  test("counts values correctly in bins", () => {
+    const data = [0, 5, 10, 12, 15, 20];
+    render(<CountHistogram data={data} s={10} />);
+    // bar 0 (0-9): [0, 5] = 2 values
+    // bar 1 (10-19): [10, 12, 15] = 3 values
+    // bar 2 (20-29): [20] = 1 value
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-1")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-2")).toBeInTheDocument();
+  });
+
+  test("handles single value correctly", () => {
+    const data = [7];
+    render(<CountHistogram data={data} s={10} />);
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+  });
+
+  test("handles values at bin boundaries", () => {
+    const data = [0, 10, 20, 30];
+    render(<CountHistogram data={data} s={10} />);
+    // 0 is in bin 0 (0-9)
+    // 10 is in bin 1 (10-19)
+    // 20 is in bin 2 (20-29)
+    // 30 is in bin 3 (30-39)
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-1")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-2")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-3")).toBeInTheDocument();
+  });
+
+  test("uses custom width and height", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} width={800} height={500} />);
+    const svg = screen.getByTestId("count-histogram");
+    expect(svg).toHaveAttribute("width", "800");
+    expect(svg).toHaveAttribute("height", "500");
+  });
+
+  test("uses default width and height", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} />);
+    const svg = screen.getByTestId("count-histogram");
+    expect(svg).toHaveAttribute("width", "600");
+    expect(svg).toHaveAttribute("height", "400");
+  });
+
+  test("handles large bin size", () => {
+    const data = [5, 12, 18, 25, 32];
+    render(<CountHistogram data={data} s={50} />);
+    // All values fall into bin 0 (0-49)
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+  });
+
+  test("handles bin size of 1", () => {
+    const data = [0, 1, 2];
+    render(<CountHistogram data={data} s={1} />);
+    // Each value gets its own bin
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-1")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-2")).toBeInTheDocument();
+  });
+
+  test("handles duplicate values", () => {
+    const data = [5, 5, 5, 15, 15];
+    render(<CountHistogram data={data} s={10} />);
+    // bin 0: [5, 5, 5] = 3 values
+    // bin 1: [15, 15] = 2 values
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+    expect(screen.getByTestId("histogram-bar-1")).toBeInTheDocument();
+  });
+
+  test("handles all zeros", () => {
+    const data = [0, 0, 0];
+    render(<CountHistogram data={data} s={10} />);
+    expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/Utils/CountHistogram.test.jsx
+++ b/frontend/src/tests/components/Utils/CountHistogram.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import CountHistogram from "main/components/Utils/CountHistogram";
+import { calculateBarHeight } from "main/components/Utils/countHistogramUtils";
 
 describe("CountHistogram component", () => {
   test("renders empty state when data is empty", () => {
@@ -102,5 +103,84 @@ describe("CountHistogram component", () => {
     const data = [0, 0, 0];
     render(<CountHistogram data={data} s={10} />);
     expect(screen.getByTestId("histogram-bar-0")).toBeInTheDocument();
+  });
+
+  test("uses default x-axis label", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} />);
+    expect(screen.getByText("Value Range")).toBeInTheDocument();
+  });
+
+  test("uses default y-axis label", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} />);
+    expect(screen.getByText("Count")).toBeInTheDocument();
+  });
+
+  test("uses custom x-axis label", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} xLabel="Cow Health" />);
+    expect(screen.getByText("Cow Health")).toBeInTheDocument();
+    expect(screen.queryByText("Value Range")).not.toBeInTheDocument();
+  });
+
+  test("uses custom y-axis label", () => {
+    const data = [1, 5, 10];
+    render(<CountHistogram data={data} s={5} yLabel="Number of Farmers" />);
+    expect(screen.getByText("Number of Farmers")).toBeInTheDocument();
+    expect(screen.queryByText("Count")).not.toBeInTheDocument();
+  });
+
+  test("uses custom both x and y axis labels", () => {
+    const data = [1, 5, 10, 15, 20];
+    render(
+      <CountHistogram data={data} s={5} xLabel="Wealth" yLabel="Frequency" />,
+    );
+    expect(screen.getByText("Wealth")).toBeInTheDocument();
+    expect(screen.getByText("Frequency")).toBeInTheDocument();
+    expect(screen.queryByText("Value Range")).not.toBeInTheDocument();
+    expect(screen.queryByText("Count")).not.toBeInTheDocument();
+  });
+
+  test("handles all negative values (maxCount is zero)", () => {
+    const data = [-5, -3, -1];
+    const { container } = render(<CountHistogram data={data} s={10} />);
+    // SVG should still render without crashing
+    expect(screen.getByTestId("count-histogram")).toBeInTheDocument();
+    // Y-axis tick groups should not be rendered when maxCount is 0 or negative
+    const tickGroups = container.querySelectorAll("g[key^='tick-']");
+    expect(tickGroups.length).toBe(0);
+  });
+});
+
+describe("calculateBarHeight", () => {
+  test("returns 0 when maxCount is 0", () => {
+    const height = calculateBarHeight(5, 0, 100);
+    expect(height).toBe(0);
+  });
+
+  test("returns 0 when count is 0 and maxCount is positive", () => {
+    const height = calculateBarHeight(0, 10, 100);
+    expect(height).toBe(0);
+  });
+
+  test("returns full chartHeight when count equals maxCount", () => {
+    const height = calculateBarHeight(10, 10, 100);
+    expect(height).toBe(100);
+  });
+
+  test("returns half chartHeight when count is half of maxCount", () => {
+    const height = calculateBarHeight(5, 10, 100);
+    expect(height).toBe(50);
+  });
+
+  test("scales correctly with different chartHeights", () => {
+    const height = calculateBarHeight(5, 10, 200);
+    expect(height).toBe(100);
+  });
+
+  test("returns 0 when maxCount is negative", () => {
+    const height = calculateBarHeight(5, -1, 100);
+    expect(height).toBe(0);
   });
 });


### PR DESCRIPTION
In this PR, we add a CountHistogram component.

This is a storybook only PR.

Link to storybook: https://67363ec2cba9cc4d32d43ff7-rlnalndmnk.chromatic.com/?path=/story/components-utils-counthistogram--uniform-distribution

After PR is merged, that link may be dead; use the main storybook instead and look under utils for CountHistogram.

This component will be used to visualize how many farmers have each number of cows on the Dashboard.

<img width="505" height="363" alt="image" src="https://github.com/user-attachments/assets/b07258d5-a704-4d02-ad10-bf4f0e0ec95e" />
