### PR TITLE
Require commons end date, gate jobs on in-progress games, auto-hide ended games

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsForm.jsx
@@ -398,19 +398,30 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           data-testid={`${testid}-r3`}
         >
           <Form.Label htmlFor="startingDate">Starting Date</Form.Label>
-          <Form.Control
-            data-testid={`${testid}-startingDate`}
-            id="startingDate"
-            type="date"
-            defaultValue={DefaultVals.startingDate}
-            isInvalid={!!errors.startingDate}
-            {...register("startingDate", {
-              valueAsDate: true,
-              validate: {
-                isPresent: (v) => !isNaN(v) || "Starting date is required",
-              },
-            })}
-          />
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip>
+                The first day of play: the game begins at midnight (00:00) at
+                the start of this date.
+              </Tooltip>
+            }
+            delay="5"
+          >
+            <Form.Control
+              data-testid={`${testid}-startingDate`}
+              id="startingDate"
+              type="date"
+              defaultValue={DefaultVals.startingDate}
+              isInvalid={!!errors.startingDate}
+              {...register("startingDate", {
+                valueAsDate: true,
+                validate: {
+                  isPresent: (v) => !isNaN(v) || "Starting date is required",
+                },
+              })}
+            />
+          </OverlayTrigger>
           <Form.Control.Feedback type="invalid">
             {errors.startingDate?.message}
           </Form.Control.Feedback>
@@ -422,22 +433,33 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           data-testid={`${testid}-r4`}
         >
           <Form.Label htmlFor="lastDate">Last Date</Form.Label>
-          <Form.Control
-            data-testid={`${testid}-lastDate`}
-            id="lastDate"
-            type="date"
-            defaultValue={DefaultVals.lastDate}
-            isInvalid={!!errors.lastDate}
-            {...register("lastDate", {
-              valueAsDate: true,
-              validate: {
-                isPresent: (v) => !isNaN(v) || "Last date is required",
-                isAfterStartingDate: (v) =>
-                  v > getValues("startingDate") ||
-                  "Last date must be after starting date",
-              },
-            })}
-          />
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip>
+                The last day of play: the game ends at midnight at the end of
+                this date.
+              </Tooltip>
+            }
+            delay="5"
+          >
+            <Form.Control
+              data-testid={`${testid}-lastDate`}
+              id="lastDate"
+              type="date"
+              defaultValue={DefaultVals.lastDate}
+              isInvalid={!!errors.lastDate}
+              {...register("lastDate", {
+                valueAsDate: true,
+                validate: {
+                  isPresent: (v) => !isNaN(v) || "Last date is required",
+                  isAfterStartingDate: (v) =>
+                    v > getValues("startingDate") ||
+                    "Last date must be after starting date",
+                },
+              })}
+            />
+          </OverlayTrigger>
           <Form.Control.Feedback type="invalid">
             {errors.lastDate?.message}
           </Form.Control.Feedback>

--- a/frontend/src/main/components/Commons/CommonsForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsForm.jsx
@@ -18,12 +18,17 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
     modifiedCommons.startingDate = modifiedCommons.startingDate.split("T")[0];
   }
 
+  if (modifiedCommons.lastDate) {
+    modifiedCommons.lastDate = modifiedCommons.lastDate.split("T")[0];
+  }
+
   // Stryker disable all
   const {
     register,
     formState: { errors },
     handleSubmit,
     reset,
+    getValues,
   } = useForm(
     // modifiedCommons is guaranteed to be defined (initialCommons or {})
     { defaultValues: modifiedCommons },
@@ -78,10 +83,12 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
   const testid = "CommonsForm";
   const curr = new Date();
   const today = curr.toLocaleDateString("en-CA"); // Canadian english gives YYYY-MM-DD
-  const currMonth = curr.getMonth() % 12;
-  const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate())
-    .toISOString()
-    .substr(0, 10);
+  // Default end date is 4 months after the default start date (today); see issue #250
+  const fourMonthsLater = new Date(
+    curr.getFullYear(),
+    curr.getMonth() + 4,
+    curr.getDate(),
+  ).toLocaleDateString("en-CA");
   const DefaultVals = {
     name: "",
     startingBalance: defaultValuesData?.startingBalance || "10000",
@@ -90,7 +97,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
     degradationRate: defaultValuesData?.degradationRate || 0.001,
     carryingCapacity: defaultValuesData?.carryingCapacity || 100,
     startingDate: today,
-    lastDate: nextMonth,
+    lastDate: fourMonthsLater,
   };
 
   const belowStrategy = defaultValuesData?.belowCapacityStrategy;
@@ -399,7 +406,9 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
             isInvalid={!!errors.startingDate}
             {...register("startingDate", {
               valueAsDate: true,
-              validate: { isPresent: (v) => !isNaN(v) },
+              validate: {
+                isPresent: (v) => !isNaN(v) || "Starting date is required",
+              },
             })}
           />
           <Form.Control.Feedback type="invalid">
@@ -421,7 +430,12 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
             isInvalid={!!errors.lastDate}
             {...register("lastDate", {
               valueAsDate: true,
-              validate: { isPresent: (v) => !isNaN(v) },
+              validate: {
+                isPresent: (v) => !isNaN(v) || "Last date is required",
+                isAfterStartingDate: (v) =>
+                  v > getValues("startingDate") ||
+                  "Last date must be after starting date",
+              },
             })}
           />
           <Form.Control.Feedback type="invalid">

--- a/frontend/src/tests/components/Commons/CommonsForm.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.jsx
@@ -180,14 +180,11 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
     const curr = new Date();
     const today = curr.toLocaleDateString("en-CA"); // Canadian english gives YYYY-MM-DD
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(
+    const fourMonthsLater = new Date(
       curr.getFullYear(),
-      currMonth + 1,
+      curr.getMonth() + 4,
       curr.getDate(),
-    )
-      .toISOString()
-      .substr(0, 10);
+    ).toLocaleDateString("en-CA");
     const DefaultVals = {
       name: "",
       startingBalance: 10000,
@@ -196,7 +193,7 @@ describe("CommonsForm tests", () => {
       degradationRate: 0.001,
       carryingCapacity: 100,
       startingDate: today,
-      lastDate: nextMonth,
+      lastDate: fourMonthsLater,
     };
 
     axiosMock
@@ -344,19 +341,111 @@ describe("CommonsForm tests", () => {
     expect(screen.getByTestId("CommonsForm-startingDate")).toHaveValue(
       commonsFixtures.threeCommons[0].startingDate.split("T")[0],
     );
+    expect(screen.getByTestId("CommonsForm-lastDate")).toHaveValue(
+      commonsFixtures.threeCommons[0].lastDate.split("T")[0],
+    );
+  });
+
+  it("has validation errors when dates are missing", async () => {
+    const submitAction = vi.fn();
+
+    axiosMock
+      .onGet("/api/commons/all-health-update-strategies")
+      .reply(200, healthUpdateStrategyListFixtures.real);
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Router>
+          <CommonsForm submitAction={submitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("CommonsForm-startingDate"), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByTestId("CommonsForm-lastDate"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByTestId("CommonsForm-Submit-Button"));
+
+    expect(
+      await screen.findByText("Starting date is required"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Last date is required")).toBeInTheDocument();
+    expect(submitAction).not.toBeCalled();
+  });
+
+  it("requires the last date to be after the starting date", async () => {
+    const submitAction = vi.fn();
+
+    axiosMock
+      .onGet("/api/commons/all-health-update-strategies")
+      .reply(200, healthUpdateStrategyListFixtures.real);
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Router>
+          <CommonsForm submitAction={submitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("CommonsForm-name"), {
+      target: { value: "My Commons" },
+    });
+    fireEvent.change(screen.getByTestId("CommonsForm-capacityPerUser"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByTestId("CommonsForm-startingDate"), {
+      target: { value: "2024-05-10" },
+    });
+
+    // equal dates are invalid: the last date must be strictly after
+    fireEvent.change(screen.getByTestId("CommonsForm-lastDate"), {
+      target: { value: "2024-05-10" },
+    });
+    fireEvent.click(screen.getByTestId("CommonsForm-Submit-Button"));
+    expect(
+      await screen.findByText("Last date must be after starting date"),
+    ).toBeInTheDocument();
+    expect(submitAction).not.toBeCalled();
+
+    // an earlier date is also invalid
+    fireEvent.change(screen.getByTestId("CommonsForm-lastDate"), {
+      target: { value: "2024-05-09" },
+    });
+    fireEvent.click(screen.getByTestId("CommonsForm-Submit-Button"));
+    expect(
+      await screen.findByText("Last date must be after starting date"),
+    ).toBeInTheDocument();
+    expect(submitAction).not.toBeCalled();
+
+    // a later date is valid
+    fireEvent.change(screen.getByTestId("CommonsForm-lastDate"), {
+      target: { value: "2024-05-11" },
+    });
+    fireEvent.click(screen.getByTestId("CommonsForm-Submit-Button"));
+    await waitFor(() => {
+      expect(submitAction).toBeCalled();
+    });
+    expect(
+      screen.queryByText("Last date must be after starting date"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
     const today = curr.toLocaleDateString("en-CA"); // Canadian english gives YYYY-MM-DD
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(
+    const fourMonthsLater = new Date(
       curr.getFullYear(),
-      currMonth + 1,
+      curr.getMonth() + 4,
       curr.getDate(),
-    )
-      .toISOString()
-      .substr(0, 10);
+    ).toLocaleDateString("en-CA");
     const DefaultVals = {
       name: "",
       startingBalance: 10000,
@@ -365,7 +454,7 @@ describe("CommonsForm tests", () => {
       degradationRate: 0.001,
       carryingCapacity: 100,
       startingDate: today,
-      lastDate: nextMonth,
+      lastDate: fourMonthsLater,
       aboveCapacityStrategy: "Linear",
       belowCapacityStrategy: "Constant",
     };
@@ -442,14 +531,11 @@ describe("CommonsForm tests", () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
     const curr = new Date();
     const today = curr.toLocaleDateString("en-CA"); // Canadian english gives YYYY-MM-DD
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(
+    const fourMonthsLater = new Date(
       curr.getFullYear(),
-      currMonth + 1,
+      curr.getMonth() + 4,
       curr.getDate(),
-    )
-      .toISOString()
-      .substr(0, 10);
+    ).toLocaleDateString("en-CA");
     const defaultValuesData = {
       name: "",
       startingBalance: 10000,
@@ -458,7 +544,7 @@ describe("CommonsForm tests", () => {
       degradationRate: 0.001,
       carryingCapacity: 100,
       startingDate: today,
-      lastDate: nextMonth,
+      lastDate: fourMonthsLater,
     };
 
     vi.spyOn(useBackendModule, "useBackend").mockReturnValue({

--- a/frontend/src/tests/components/Commons/CommonsForm.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.jsx
@@ -346,6 +346,36 @@ describe("CommonsForm tests", () => {
     );
   });
 
+  it("shows explanatory tooltips over the starting and last date fields", async () => {
+    axiosMock
+      .onGet("/api/commons/all-health-update-strategies")
+      .reply(200, healthUpdateStrategyListFixtures.real);
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Router>
+          <CommonsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("CommonsForm-startingDate"));
+    expect(
+      await screen.findByText(
+        "The first day of play: the game begins at midnight (00:00) at the start of this date.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("CommonsForm-lastDate"));
+    expect(
+      await screen.findByText(
+        "The last day of play: the game ends at midnight at the end of this date.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("has validation errors when dates are missing", async () => {
     const submitAction = vi.fn();
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -200,6 +200,8 @@ public class CommonsController extends ApiController {
             throw new IllegalArgumentException("Carrying Capacity cannot be less than 1");
         }
 
+        validateDates(params);
+
         updated.setHidden(params.isHidden());
         commonsRepository.save(updated);
 
@@ -275,10 +277,31 @@ public class CommonsController extends ApiController {
             throw new IllegalArgumentException("Carrying Capacity cannot be less than 1");
         }
 
+        validateDates(params);
+
         Commons saved = commonsRepository.save(commons);
         String body = mapper.writeValueAsString(saved);
 
         return ResponseEntity.ok().body(body);
+    }
+
+    /**
+     * Enforce that both dates are present and that the last date is strictly
+     * after the starting date.  (See issue #250; the frontend form enforces
+     * the same rules, but the backend must not rely on that.)
+     *
+     * @param params the params to validate
+     */
+    public static void validateDates(CreateCommonsParams params) {
+        if (params.getStartingDate() == null) {
+            throw new IllegalArgumentException("Starting Date is required");
+        }
+        if (params.getLastDate() == null) {
+            throw new IllegalArgumentException("Last Date is required");
+        }
+        if (!params.getLastDate().isAfter(params.getStartingDate())) {
+            throw new IllegalArgumentException("Last Date must be after Starting Date");
+        }
     }
 
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -57,17 +57,18 @@ public class Commons {
     private List<UserCommons> joinedUsers;
 
     /**
-     * A game is in progress when <code>now</code> is later than midnight
-     * (00:00 local time) at the beginning of the starting date, and before
-     * midnight (00:00 local time) at the beginning of the last date.
+     * The starting date is the first day of play, and the last date is the
+     * last day of play: a game is in progress from midnight (00:00 local
+     * time) at the beginning of the starting date, up to (but not including)
+     * midnight at the end of the last date.
      *
      * @param now the date/time to check against
      * @return whether the game is in progress at <code>now</code>
      */
     public boolean gameInProgress(LocalDateTime now) {
         LocalDateTime gameStart = startingDate.toLocalDate().atStartOfDay();
-        LocalDateTime gameEnd = lastDate.toLocalDate().atStartOfDay();
-        return now.isAfter(gameStart) && now.isBefore(gameEnd);
+        LocalDateTime gameEnd = lastDate.toLocalDate().plusDays(1).atStartOfDay();
+        return !now.isBefore(gameStart) && now.isBefore(gameEnd);
     }
 
     public boolean gameInProgress() {
@@ -76,13 +77,14 @@ public class Commons {
 
     /**
      * The end date has passed when <code>now</code> is at or after midnight
-     * (00:00 local time) at the beginning of the last date.
+     * at the end of the last date (i.e. the last date is the last day of
+     * play).
      *
      * @param now the date/time to check against
      * @return whether the game has ended as of <code>now</code>
      */
     public boolean endDateHasPassed(LocalDateTime now) {
-        LocalDateTime gameEnd = lastDate.toLocalDate().atStartOfDay();
+        LocalDateTime gameEnd = lastDate.toLocalDate().plusDays(1).atStartOfDay();
         return !now.isBefore(gameEnd);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -28,7 +28,10 @@ public class Commons {
     private double milkPrice;
     private double startingBalance;
     private LocalDateTime startingDate;
+
+    @Column(nullable = false)
     private LocalDateTime lastDate;
+
     private boolean showLeaderboard;
 
     @Builder.Default
@@ -53,11 +56,33 @@ public class Commons {
     @JsonIgnore
     private List<UserCommons> joinedUsers;
 
+    /**
+     * A game is in progress when <code>now</code> is later than midnight
+     * (00:00 local time) at the beginning of the starting date, and before
+     * midnight (00:00 local time) at the beginning of the last date.
+     *
+     * @param now the date/time to check against
+     * @return whether the game is in progress at <code>now</code>
+     */
+    public boolean gameInProgress(LocalDateTime now) {
+        LocalDateTime gameStart = startingDate.toLocalDate().atStartOfDay();
+        LocalDateTime gameEnd = lastDate.toLocalDate().atStartOfDay();
+        return now.isAfter(gameStart) && now.isBefore(gameEnd);
+    }
+
     public boolean gameInProgress() {
-        LocalDateTime today = LocalDateTime.now();
-        if (startingDate.isBefore(today) && lastDate.isAfter(today)) {
-            return true;
-        }
-        return false;
+        return gameInProgress(LocalDateTime.now());
+    }
+
+    /**
+     * The end date has passed when <code>now</code> is at or after midnight
+     * (00:00 local time) at the beginning of the last date.
+     *
+     * @param now the date/time to check against
+     * @return whether the game has ended as of <code>now</code>
+     */
+    public boolean endDateHasPassed(LocalDateTime now) {
+        LocalDateTime gameEnd = lastDate.toLocalDate().atStartOfDay();
+        return !now.isBefore(gameEnd);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonsGate.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonsGate.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import java.time.LocalDateTime;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+
+/**
+ * A shared gate used by every job (scheduled or on demand) that operates on a
+ * commons: jobs should only touch games that are in progress (see
+ * {@link Commons#gameInProgress(LocalDateTime)}).
+ *
+ * As a side effect, when a commons whose end date has passed is encountered,
+ * it is automatically hidden (see issue #250).
+ */
+public class CommonsGate {
+
+    /**
+     * Determine whether a job should process the given commons.
+     *
+     * If the game is not in progress, a skip message is logged; additionally,
+     * if the game has ended and the commons is not yet hidden, it is hidden
+     * and saved.
+     *
+     * @param commons the commons the job wants to process
+     * @param commonsRepository repository used to save the commons when it is auto-hidden
+     * @param ctx the job context, for logging
+     * @return true if the game is in progress and the job should proceed
+     */
+    public static boolean shouldProcess(Commons commons, CommonsRepository commonsRepository, JobContext ctx) {
+        LocalDateTime now = LocalDateTime.now();
+        if (commons.gameInProgress(now)) {
+            return true;
+        }
+        ctx.log(String.format("Skipping Commons id=%d (%s) because the game is not in progress",
+                commons.getId(), commons.getName()));
+        if (commons.endDateHasPassed(now) && !commons.isHidden()) {
+            commons.setHidden(true);
+            commonsRepository.save(commons);
+            ctx.log(String.format("Commons id=%d (%s) has ended; setting hidden to true",
+                    commons.getId(), commons.getName()));
+        }
+        return false;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
@@ -24,6 +24,9 @@ public class InstructorReportJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!CommonsGate.shouldProcess(commons, commonsRepository, ctx)) {
+                continue;
+            }
             ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
             Report report = reportService.createReport(commons.getId());
             ctx.log(String.format("Report %d for commons id=%d (%s) finished.", report.getId(), commons.getId(),

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommons.java
@@ -1,7 +1,11 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 
+import java.util.Optional;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.ReportService;
@@ -16,10 +20,21 @@ public class InstructorReportJobSingleCommons implements JobContextConsumer {
 
     @Getter
     private ReportService reportService;
-    
+
+    @Getter
+    private CommonsRepository commonsRepository;
+
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Producing instructor report for commons id: " + commonsId);
+        Optional<Commons> commonsOpt = commonsRepository.findById(commonsId);
+        if (!commonsOpt.isPresent()) {
+            ctx.log(String.format("No commons found for id %d", commonsId));
+            return;
+        }
+        if (!CommonsGate.shouldProcess(commonsOpt.get(), commonsRepository, ctx)) {
+            return;
+        }
         Report report = reportService.createReport(commonsId);
         ctx.log(String.format("Instructor report %d for commons %s has been produced!", report.getId(), report.getName()));
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactory.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 
@@ -12,8 +13,11 @@ public class InstructorReportJobSingleCommonsFactory {
     @Autowired
     private ReportService reportService;
 
+    @Autowired
+    private CommonsRepository commonsRepository;
+
     public JobContextConsumer create(long commonsId) {
-        return new InstructorReportJobSingleCommons(commonsId, reportService);
+        return new InstructorReportJobSingleCommons(commonsId, reportService, commonsRepository);
     }
   
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -38,6 +38,9 @@ public class MilkTheCowsJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!CommonsGate.shouldProcess(commons, commonsRepository, ctx)) {
+                continue;
+            }
             String name = commons.getName();
             double milkPrice = commons.getMilkPrice();
             ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobInd.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobInd.java
@@ -38,6 +38,9 @@ public class MilkTheCowsJobInd implements JobContextConsumer {
 
         if(commonMilkedOpt.isPresent()){
             Commons commonMilked = commonMilkedOpt.get();
+            if (!CommonsGate.shouldProcess(commonMilked, commonsRepository, ctx)) {
+                return;
+            }
             String name = commonMilked.getName();
             double milkPrice = commonMilked.getMilkPrice();
             ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -28,6 +28,9 @@ public class RecordCommonStatsJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!CommonsGate.shouldProcess(commons, commonsRepository, ctx)) {
+                continue;
+            }
             ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
             CommonStats commonStats = commonStatsService.createAndSaveCommonStats(commons.getId());
             ctx.log(String.format("CommonStats %d for commons id=%d (%s) finished.", commonStats.getId(), commons.getId(),

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
@@ -35,6 +35,9 @@ public class SetCowHealthJob implements JobContextConsumer {
 
 
         if (commons.isPresent()) {
+            if (!CommonsGate.shouldProcess(commons.get(), commonsRepository, ctx)) {
+                return;
+            }
             ctx.log("Commons " + commons.get().getName());
 
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -38,9 +38,13 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
 
             Commons commons = commonsPlus.getCommons();
-            
+
+            if (!CommonsGate.shouldProcess(commons, commonsRepository, ctx)) {
+                continue;
+            }
+
             runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
-            
+
         }
 
         ctx.log("Cow health has been updated!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobInd.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobInd.java
@@ -36,6 +36,9 @@ public class UpdateCowHealthJobInd implements JobContextConsumer {
 
         if(commonUpdatedOpt.isPresent()){
             Commons commonsUpdated = commonUpdatedOpt.get();
+            if (!CommonsGate.shouldProcess(commonsUpdated, commonsRepository, ctx)) {
+                return;
+            }
             CommonsPlus commonsPlus = commonsPlusBuilderService.toCommonsPlus(commonsUpdated);
             UpdateCowHealthJob.runUpdateJobInCommons(commonsUpdated, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx); 
             ctx.log("Cow health has been updated!");

--- a/src/main/resources/db/migration/changes/002_require_last_date_on_commons.json
+++ b/src/main/resources/db/migration/changes/002_require_last_date_on_commons.json
@@ -1,0 +1,33 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "002-Require-Last-Date-On-Commons",
+        "author": "pconrad",
+        "changes": [
+          {
+            "update": {
+              "tableName": "COMMONS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "LAST_DATE",
+                    "valueComputed": "COALESCE(STARTING_DATE, CURRENT_TIMESTAMP)"
+                  }
+                }
+              ],
+              "where": "LAST_DATE IS NULL"
+            }
+          },
+          {
+            "addNotNullConstraint": {
+              "tableName": "COMMONS",
+              "columnName": "LAST_DATE",
+              "columnDataType": "TIMESTAMP"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -112,6 +112,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void createCommonsTest() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         Commons commons = Commons.builder()
                 .name("Jackson's Commons")
@@ -119,6 +120,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -135,6 +137,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -169,6 +172,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void createCommonsTest_withNoCowHealthUpdateStrategies() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         Commons commons = Commons.builder()
                 .name("Jackson's Commons")
@@ -176,6 +180,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -190,6 +195,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -225,6 +231,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void createCommonsTest_zeroDegradation() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         Commons commons = Commons.builder()
                 .name("Jackson's Commons")
@@ -232,6 +239,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .showChat(true)
@@ -246,6 +254,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .showChat(true)
@@ -278,6 +287,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void createCommonsTest_withIllegalDegradationRate() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         Commons commons = Commons.builder()
                 .name("Jackson's Commons")
@@ -285,6 +295,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(-8.49)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
@@ -297,6 +308,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(-8.49)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
@@ -341,6 +353,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void updateCommonsTest() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
                 .name("Jackson's Commons")
@@ -348,7 +361,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
-                .lastDate(someTime)
+                .lastDate(someLaterTime)
                 .showChat(true)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
@@ -365,7 +378,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
-                .lastDate(someTime)
+                .lastDate(someLaterTime)
                 .showChat(true)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
@@ -436,6 +449,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void updateCommonsTest_withNoCowHealthUpdateStrategy() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
                 .name("Jackson's Commons")
@@ -443,6 +457,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .showChat(false)
@@ -457,6 +472,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .showChat(false)
@@ -494,6 +510,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
                 .name("Jackson's Commons")
@@ -501,6 +518,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -515,6 +533,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -568,6 +587,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
                 .name("Jackson's Commons")
@@ -575,6 +595,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -589,6 +610,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -636,6 +658,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void updateCommonsTest_hiddenCanBeToggled() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
                 .name("Jackson's Commons")
@@ -643,6 +666,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -657,6 +681,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -899,6 +924,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void deleteCommons_test_admin_exists() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
 
         Commons c = Commons.builder()
                 .name("Jackson's Commons")
@@ -906,6 +932,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .milkPrice(8.99)
                 .startingBalance(1020.10)
                 .startingDate(someTime)
+                .lastDate(someLaterTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -1214,6 +1241,8 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .cowPrice(0.01)
                 .milkPrice(0.01)
                 .startingBalance(0.0)
+                .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                .lastDate(LocalDateTime.parse("2022-07-05T15:50:10"))
                 .degradationRate(0.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -1237,12 +1266,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     public void UpdateCommonsTest_withIllegalParameters() throws Exception {
         // we first create a commons to update
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
         Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .lastDate(someLaterTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .showChat(false)
@@ -1376,12 +1407,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     public void UpdateCommonsTest_withBoundaryParameters() throws Exception {
         // we first create a commons to update
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
         Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .lastDate(someLaterTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .showChat(false)
@@ -1399,6 +1432,8 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .cowPrice(0.01)
                 .milkPrice(0.01)
                 .startingBalance(0.0)
+                .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                .lastDate(LocalDateTime.parse("2022-07-05T15:50:10"))
                 .degradationRate(0.0)
                 .showLeaderboard(false)
                 .showChat(false)
@@ -1423,12 +1458,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test void test_capacity_with_lower_per_user() throws Exception{
         
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
         Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .lastDate(someLaterTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .showChat(false)
@@ -1447,12 +1484,14 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test void test_capacity_with_higher_per_user() throws Exception{
         
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime someLaterTime = LocalDateTime.parse("2022-07-05T15:50:10");
         Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .lastDate(someLaterTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .showChat(false)
@@ -1573,4 +1612,136 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .andExpect(status().is(403)).andReturn();
     }
 
+    private CreateCommonsParams.CreateCommonsParamsBuilder validParamsBuilder() {
+        return CreateCommonsParams.builder()
+                .name("Test Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                .lastDate(LocalDateTime.parse("2022-07-05T15:50:10"))
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .showChat(false)
+                .capacityPerUser(10)
+                .carryingCapacity(100);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_startingDateMissing_badRequest() throws Exception {
+        CreateCommonsParams parameters = validParamsBuilder().startingDate(null).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        mockMvc.perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_lastDateMissing_badRequest() throws Exception {
+        CreateCommonsParams parameters = validParamsBuilder().lastDate(null).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        mockMvc.perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_lastDateEqualsStartingDate_badRequest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        CreateCommonsParams parameters = validParamsBuilder()
+                .startingDate(someTime).lastDate(someTime).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        mockMvc.perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_lastDateBeforeStartingDate_badRequest() throws Exception {
+        CreateCommonsParams parameters = validParamsBuilder()
+                .startingDate(LocalDateTime.parse("2022-07-05T15:50:10"))
+                .lastDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                .build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        mockMvc.perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_startingDateMissing_badRequest() throws Exception {
+        CreateCommonsParams parameters = validParamsBuilder().startingDate(null).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(eq(0L))).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_lastDateMissing_badRequest() throws Exception {
+        CreateCommonsParams parameters = validParamsBuilder().lastDate(null).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(eq(0L))).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_lastDateNotAfterStartingDate_badRequest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        CreateCommonsParams parameters = validParamsBuilder()
+                .startingDate(someTime).lastDate(someTime).build();
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(eq(0L))).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(commonsRepository, times(0)).save(any());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTests.java
@@ -1,10 +1,8 @@
 package edu.ucsb.cs156.happiercows.entities;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import edu.ucsb.cs156.happiercows.entities.User;
+
 import org.junit.jupiter.api.Test;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.time.LocalDateTime;
 
 public class CommonsTests {
@@ -12,6 +10,15 @@ public class CommonsTests {
     LocalDateTime start2 = LocalDateTime.parse("2100-03-05T15:50:10");
     LocalDateTime end = LocalDateTime.parse("2200-01-21T06:47:22.756");
     LocalDateTime end2 = LocalDateTime.parse("2021-03-05T15:50:10");
+
+    // For the parameterized versions, use a game with a start date of
+    // 2024-01-10 (with a time of day of 14:30) and a last date of
+    // 2024-01-20 (with a time of day of 09:15).  The game is in progress
+    // strictly after 2024-01-10T00:00 and strictly before 2024-01-20T00:00.
+    Commons game = Commons.builder()
+            .startingDate(LocalDateTime.parse("2024-01-10T14:30:00"))
+            .lastDate(LocalDateTime.parse("2024-01-20T09:15:00"))
+            .build();
 
     @Test
     void test_gameInProgress_true() throws Exception {
@@ -23,6 +30,58 @@ public class CommonsTests {
     }
     @Test
     void test_gameInProgress_ended() throws Exception {
-        assertEquals(false, Commons.builder().startingDate(start).lastDate(end2).build().gameInProgress());       
+        assertEquals(false, Commons.builder().startingDate(start).lastDate(end2).build().gameInProgress());
+    }
+
+    @Test
+    void test_gameInProgress_false_before_start_date() throws Exception {
+        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-09T23:59:59")));
+    }
+
+    @Test
+    void test_gameInProgress_false_exactly_at_midnight_on_start_date() throws Exception {
+        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-10T00:00:00")));
+    }
+
+    @Test
+    void test_gameInProgress_true_just_after_midnight_on_start_date() throws Exception {
+        // note: 00:00:01 on the start date is before the 14:30 time of day
+        // stored in startingDate; only the date portion matters
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-10T00:00:01")));
+    }
+
+    @Test
+    void test_gameInProgress_true_in_the_middle_of_the_game() throws Exception {
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-15T12:00:00")));
+    }
+
+    @Test
+    void test_gameInProgress_true_just_before_midnight_on_last_date() throws Exception {
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-19T23:59:59")));
+    }
+
+    @Test
+    void test_gameInProgress_false_exactly_at_midnight_on_last_date() throws Exception {
+        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-20T00:00:00")));
+    }
+
+    @Test
+    void test_gameInProgress_false_after_last_date() throws Exception {
+        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-21T12:00:00")));
+    }
+
+    @Test
+    void test_endDateHasPassed_false_before_midnight_on_last_date() throws Exception {
+        assertEquals(false, game.endDateHasPassed(LocalDateTime.parse("2024-01-19T23:59:59")));
+    }
+
+    @Test
+    void test_endDateHasPassed_true_exactly_at_midnight_on_last_date() throws Exception {
+        assertEquals(true, game.endDateHasPassed(LocalDateTime.parse("2024-01-20T00:00:00")));
+    }
+
+    @Test
+    void test_endDateHasPassed_true_after_last_date() throws Exception {
+        assertEquals(true, game.endDateHasPassed(LocalDateTime.parse("2024-02-01T12:00:00")));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTests.java
@@ -13,8 +13,10 @@ public class CommonsTests {
 
     // For the parameterized versions, use a game with a start date of
     // 2024-01-10 (with a time of day of 14:30) and a last date of
-    // 2024-01-20 (with a time of day of 09:15).  The game is in progress
-    // strictly after 2024-01-10T00:00 and strictly before 2024-01-20T00:00.
+    // 2024-01-20 (with a time of day of 09:15).  The starting date is the
+    // first day of play and the last date is the last day of play, so the
+    // game is in progress from 2024-01-10T00:00 (inclusive) up to
+    // 2024-01-21T00:00 (exclusive).
     Commons game = Commons.builder()
             .startingDate(LocalDateTime.parse("2024-01-10T14:30:00"))
             .lastDate(LocalDateTime.parse("2024-01-20T09:15:00"))
@@ -39,8 +41,9 @@ public class CommonsTests {
     }
 
     @Test
-    void test_gameInProgress_false_exactly_at_midnight_on_start_date() throws Exception {
-        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-10T00:00:00")));
+    void test_gameInProgress_true_exactly_at_midnight_on_start_date() throws Exception {
+        // the starting date is the first day of play, beginning at midnight
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-10T00:00:00")));
     }
 
     @Test
@@ -56,13 +59,19 @@ public class CommonsTests {
     }
 
     @Test
-    void test_gameInProgress_true_just_before_midnight_on_last_date() throws Exception {
-        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-19T23:59:59")));
+    void test_gameInProgress_true_at_start_of_last_date() throws Exception {
+        // the last date is the last day of play, so it counts
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-20T00:00:00")));
     }
 
     @Test
-    void test_gameInProgress_false_exactly_at_midnight_on_last_date() throws Exception {
-        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-20T00:00:00")));
+    void test_gameInProgress_true_just_before_the_end_of_the_last_date() throws Exception {
+        assertEquals(true, game.gameInProgress(LocalDateTime.parse("2024-01-20T23:59:59")));
+    }
+
+    @Test
+    void test_gameInProgress_false_exactly_at_midnight_after_last_date() throws Exception {
+        assertEquals(false, game.gameInProgress(LocalDateTime.parse("2024-01-21T00:00:00")));
     }
 
     @Test
@@ -71,13 +80,13 @@ public class CommonsTests {
     }
 
     @Test
-    void test_endDateHasPassed_false_before_midnight_on_last_date() throws Exception {
-        assertEquals(false, game.endDateHasPassed(LocalDateTime.parse("2024-01-19T23:59:59")));
+    void test_endDateHasPassed_false_during_the_last_date() throws Exception {
+        assertEquals(false, game.endDateHasPassed(LocalDateTime.parse("2024-01-20T23:59:59")));
     }
 
     @Test
-    void test_endDateHasPassed_true_exactly_at_midnight_on_last_date() throws Exception {
-        assertEquals(true, game.endDateHasPassed(LocalDateTime.parse("2024-01-20T00:00:00")));
+    void test_endDateHasPassed_true_exactly_at_midnight_after_last_date() throws Exception {
+        assertEquals(true, game.endDateHasPassed(LocalDateTime.parse("2024-01-21T00:00:00")));
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/integration/CommonsIT.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/integration/CommonsIT.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,7 +66,11 @@ public class CommonsIT {
     @Test
     public void getCommonsTest() throws Exception {
         List<Commons> expectedCommons = new ArrayList<Commons>();
-        Commons Commons1 = Commons.builder().name("TestCommons1").build();
+        Commons Commons1 = Commons.builder()
+                .name("TestCommons1")
+                .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                .lastDate(LocalDateTime.parse("2022-07-05T15:50:10"))
+                .build();
         expectedCommons.add(Commons1);
 
         commonsRepository.save(Commons1);

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonsGateTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonsGateTests.java
@@ -1,0 +1,112 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.JobTestCase;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class CommonsGateTests extends JobTestCase {
+
+    @Mock
+    CommonsRepository commonsRepository;
+
+    private Commons commonsWithDates(LocalDateTime startingDate, LocalDateTime lastDate, boolean hidden) {
+        return Commons.builder()
+                .id(42L)
+                .name("CS156")
+                .startingDate(startingDate)
+                .lastDate(lastDate)
+                .hidden(hidden)
+                .build();
+    }
+
+    @Test
+    void gate_can_be_instantiated() {
+        assertNotNull(new CommonsGate());
+    }
+
+    @Test
+    void shouldProcess_returns_true_and_logs_nothing_when_game_in_progress() {
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons commons = commonsWithDates(
+                LocalDateTime.now().minusDays(5), LocalDateTime.now().plusDays(5), false);
+
+        assertTrue(CommonsGate.shouldProcess(commons, commonsRepository, ctx));
+
+        assertEquals(null, jobStarted.getLog());
+        verify(commonsRepository, never()).save(any());
+        assertFalse(commons.isHidden());
+    }
+
+    @Test
+    void shouldProcess_returns_false_and_does_not_hide_when_game_not_yet_started() {
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons commons = commonsWithDates(
+                LocalDateTime.now().plusDays(5), LocalDateTime.now().plusDays(10), false);
+
+        assertFalse(CommonsGate.shouldProcess(commons, commonsRepository, ctx));
+
+        String expected = """
+                Skipping Commons id=42 (CS156) because the game is not in progress""";
+        assertEquals(expected, jobStarted.getLog());
+        verify(commonsRepository, never()).save(any());
+        assertFalse(commons.isHidden());
+    }
+
+    @Test
+    void shouldProcess_returns_false_and_hides_commons_when_game_has_ended() {
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons commons = commonsWithDates(
+                LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(5), false);
+
+        assertFalse(CommonsGate.shouldProcess(commons, commonsRepository, ctx));
+
+        String expected = """
+                Skipping Commons id=42 (CS156) because the game is not in progress
+                Commons id=42 (CS156) has ended; setting hidden to true""";
+        assertEquals(expected, jobStarted.getLog());
+        assertTrue(commons.isHidden());
+        verify(commonsRepository).save(commons);
+    }
+
+    @Test
+    void shouldProcess_does_not_save_again_when_ended_commons_is_already_hidden() {
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons commons = commonsWithDates(
+                LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(5), true);
+
+        assertFalse(CommonsGate.shouldProcess(commons, commonsRepository, ctx));
+
+        String expected = """
+                Skipping Commons id=42 (CS156) because the game is not in progress""";
+        assertEquals(expected, jobStarted.getLog());
+        verify(commonsRepository, never()).save(any());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsFactoryTests.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import edu.ucsb.cs156.happiercows.JobTestCase;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.wiremock.WiremockService;
 
@@ -19,7 +20,10 @@ public class InstructorReportJobSingleCommonsFactoryTests extends JobTestCase {
 
     @MockBean
     ReportService reportService;
- 
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
     @Autowired
     InstructorReportJobSingleCommonsFactory InstructorReportJobSingleCommonsFactory;
 
@@ -32,6 +36,7 @@ public class InstructorReportJobSingleCommonsFactoryTests extends JobTestCase {
         // Assert
         assertEquals(17L,instructorReportJobSingleCommons.getCommonsId());
         assertEquals(reportService,instructorReportJobSingleCommons.getReportService());
+        assertEquals(commonsRepository,instructorReportJobSingleCommons.getCommonsRepository());
     }
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
@@ -1,8 +1,13 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +16,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import edu.ucsb.cs156.happiercows.JobTestCase;
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
@@ -23,29 +30,88 @@ public class InstructorReportJobSingleCommonsTests extends JobTestCase {
     @MockBean
     ReportService reportService;
 
+    @MockBean
+    CommonsRepository commonsRepository;
+
     @Test
     void test_log_output() throws Exception {
 
         // Arrange
 
+        Commons commons = Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().minusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(5))
+                .build();
         Report report = Report.builder().id(17L).name("Foo").build();
-        
+
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
-      
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(reportService.createReport(17L)).thenReturn(report);
 
         // Act
-        InstructorReportJobSingleCommons InstructorReportJobSingleCommons = new InstructorReportJobSingleCommons(17L, reportService);
+        InstructorReportJobSingleCommons InstructorReportJobSingleCommons = new InstructorReportJobSingleCommons(17L, reportService, commonsRepository);
         InstructorReportJobSingleCommons.accept(ctx);
 
         // Assert
 
         verify(reportService).createReport(17L);
-        
+
         String expected = """
             Producing instructor report for commons id: 17
             Instructor report 17 for commons Foo has been produced!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_when_no_commons_found() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.empty());
+
+        // Act
+        InstructorReportJobSingleCommons instructorReportJobSingleCommons = new InstructorReportJobSingleCommons(17L, reportService, commonsRepository);
+        instructorReportJobSingleCommons.accept(ctx);
+
+        // Assert
+        verify(reportService, never()).createReport(anyLong());
+
+        String expected = """
+            Producing instructor report for commons id: 17
+            No commons found for id 17""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Commons commons = Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+
+        // Act
+        InstructorReportJobSingleCommons instructorReportJobSingleCommons = new InstructorReportJobSingleCommons(17L, reportService, commonsRepository);
+        instructorReportJobSingleCommons.accept(ctx);
+
+        // Assert
+        verify(reportService, never()).createReport(anyLong());
+
+        String expected = """
+            Producing instructor report for commons id: 17
+            Skipping Commons id=17 (CS156) because the game is not in progress""";
 
         assertEquals(expected, jobStarted.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -1,9 +1,12 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +38,10 @@ public class InstructorReportJobTests extends JobTestCase {
 
         // Arrange
 
-        Commons commons= Commons.builder().id(17L).name("CS156").build();
+        Commons commons= Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().minusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(5))
+                .build();
         Report report = Report.builder().id(17L).build();
         
         Job jobStarted = Job.builder().build();
@@ -57,6 +63,35 @@ public class InstructorReportJobTests extends JobTestCase {
             Starting instructor report...
             Starting Commons id=17 (CS156)...
             Report 17 for commons id=17 (CS156) finished.
+            Instructor report done!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Commons commons = Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));
+
+        // Act
+        InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
+        instructorReportJob.accept(ctx);
+
+        // Assert
+        verify(reportService, never()).createReport(anyLong());
+
+        String expected = """
+            Starting instructor report...
+            Skipping Commons id=17 (CS156) because the game is not in progress
             Instructor report done!""";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
@@ -52,7 +52,8 @@ public class MilkTheCowsJobIndTests extends JobTestCase {
             .cowPrice(10)
             .milkPrice(2)
             .startingBalance(300)
-            .startingDate(LocalDateTime.now())
+            .startingDate(LocalDateTime.now().minusDays(5))
+            .lastDate(LocalDateTime.now().plusDays(5))
             .carryingCapacity(100)
             .degradationRate(0.01)
             .build();
@@ -115,6 +116,40 @@ public class MilkTheCowsJobIndTests extends JobTestCase {
                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0, totalWealth: $300.00
                 Profit for user: Chris Gaucho is: $0.20, newWealth: $300.20
                 Cows have been milked!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons futureCommons = Commons
+                .builder()
+                .name("future commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(futureCommons));
+
+        // Act
+        MilkTheCowsJobInd milkTheCowsJobInd = new MilkTheCowsJobInd(commonsRepository, userCommonsRepository,
+                userRepository, profitRepository, 1L);
+        milkTheCowsJobInd.accept(ctx);
+
+        // Assert
+        String expected = """
+                Starting to milk the cows
+                Skipping Commons id=0 (future commons) because the game is not in progress""";
 
         assertEquals(expected, jobStarted.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -52,7 +52,8 @@ public class MilkTheCowsJobTests extends JobTestCase {
             .cowPrice(10)
             .milkPrice(2)
             .startingBalance(300)
-            .startingDate(LocalDateTime.now())
+            .startingDate(LocalDateTime.now().minusDays(5))
+            .lastDate(LocalDateTime.now().plusDays(5))
             .carryingCapacity(100)
             .degradationRate(0.01)
             .build();
@@ -115,6 +116,41 @@ public class MilkTheCowsJobTests extends JobTestCase {
                 Milking cows for Commons: test commons, Milk Price: $2.00
                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0, totalWealth: $300.00
                 Profit for user: Chris Gaucho is: $0.20, newWealth: $300.20
+                Cows have been milked!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons futureCommons = Commons
+                .builder()
+                .name("future commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(futureCommons));
+
+        // Act
+        MilkTheCowsJob milkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
+                userRepository, profitRepository);
+        milkTheCowsJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Starting to milk the cows
+                Skipping Commons id=0 (future commons) because the game is not in progress
                 Cows have been milked!""";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
@@ -1,9 +1,12 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -40,7 +43,10 @@ public class RecordCommonStatsJobTests extends JobTestCase {
 
         // Arrange
 
-        Commons commons= Commons.builder().id(17L).name("CS156").build();
+        Commons commons= Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().minusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(5))
+                .build();
         CommonStats commonStats = CommonStats.builder().id(17L).build();
         
         Job jobStarted = Job.builder().build();
@@ -63,6 +69,35 @@ public class RecordCommonStatsJobTests extends JobTestCase {
             Starting record common stats job...
             Starting Commons id=17 (CS156)...
             CommonStats 17 for commons id=17 (CS156) finished.
+            Record common stats job done!""";
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Commons commons = Commons.builder().id(17L).name("CS156")
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));
+
+        // Act
+        RecordCommonStatsJob recordCommonStatsJob =
+                new RecordCommonStatsJob(commonStatsService, commonsRepository);
+        recordCommonStatsJob.accept(ctx);
+
+        // Assert
+        verify(commonStatsService, never()).createAndSaveCommonStats(anyLong());
+
+        String expected = """
+            Starting record common stats job...
+            Skipping Commons id=17 (CS156) because the game is not in progress
             Record common stats job done!""";
         assertEquals(expected, jobStarted.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -49,7 +49,8 @@ public class SetCowHealthJobTests extends JobTestCase {
             .cowPrice(10)
             .milkPrice(2)
             .startingBalance(300)
-            .startingDate(LocalDateTime.now())
+            .startingDate(LocalDateTime.now().minusDays(5))
+            .lastDate(LocalDateTime.now().plusDays(5))
             .carryingCapacity(100)
             .degradationRate(0.01)
             .build();
@@ -79,6 +80,41 @@ public class SetCowHealthJobTests extends JobTestCase {
 
     }
 
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        Commons futureCommons = Commons
+                .builder()
+                .id(117L)
+                .name("future commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        when(commonsRepository.findById(117L)).thenReturn(Optional.of(futureCommons));
+
+        // Act
+        SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117L, 2.0, commonsRepository, userCommonsRepository,
+                userRepository);
+        setCowHealthJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Setting cow health...
+                Skipping Commons id=117 (future commons) because the game is not in progress""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
 
     UserCommons getUserCommons() {
         return UserCommons

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
@@ -62,7 +62,8 @@ public class UpdateCowHealthJobIndTests extends JobTestCase {
                         .cowPrice(10)
                         .milkPrice(2)
                         .startingBalance(300)
-                        .startingDate(LocalDateTime.now())
+                        .startingDate(LocalDateTime.now().minusDays(5))
+                        .lastDate(LocalDateTime.now().plusDays(5))
                         .capacityPerUser(1)
                         .carryingCapacity(100)
                         .degradationRate(1)
@@ -134,6 +135,27 @@ public class UpdateCowHealthJobIndTests extends JobTestCase {
                         User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                          old cow health: 10.0, new cow health: 100.0
                         Cow health has been updated!""";
+
+        assertEquals(expected, job.getLog());
+    }
+
+    @Test
+    void test_skips_commons_when_game_not_in_progress() throws Exception {
+
+        Commons futureCommons = Commons
+                .builder()
+                .name("future commons")
+                .startingDate(LocalDateTime.now().plusDays(5))
+                .lastDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(futureCommons));
+
+        runUpdateCowHealthJob();
+
+        String expected = """
+                        Updating cow health...
+                        Skipping Commons id=0 (future commons) because the game is not in progress""";
 
         assertEquals(expected, job.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -60,7 +60,8 @@ public class UpdateCowHealthJobTests extends JobTestCase {
                         .cowPrice(10)
                         .milkPrice(2)
                         .startingBalance(300)
-                        .startingDate(LocalDateTime.now())
+                        .startingDate(LocalDateTime.now().minusDays(5))
+                        .lastDate(LocalDateTime.now().plusDays(5))
                         .capacityPerUser(0)
                         .carryingCapacity(100)
                         .degradationRate(1)
@@ -96,6 +97,32 @@ public class UpdateCowHealthJobTests extends JobTestCase {
 
                 String expected = """
                                 Updating cow health...
+                                Cow health has been updated!""";
+                assertEquals(expected, job.getLog());
+        }
+
+        @Test
+        void test_skips_commons_when_game_not_in_progress() throws Exception {
+                Commons futureCommons = Commons
+                                .builder()
+                                .name("future commons")
+                                .startingDate(LocalDateTime.now().plusDays(5))
+                                .lastDate(LocalDateTime.now().plusDays(10))
+                                .build();
+
+                List<Commons> listOfCommons = List.of(futureCommons);
+                CommonsPlus futureCommonsPlus = CommonsPlus.builder().commons(futureCommons).totalCows(1)
+                                .totalUsers(1).build();
+
+                when(commonsRepository.findAll()).thenReturn(listOfCommons);
+                when(commonsPlusBuilderService.convertToCommonsPlus(eq(listOfCommons)))
+                                .thenReturn(List.of(futureCommonsPlus));
+
+                runUpdateCowHealthJob();
+
+                String expected = """
+                                Updating cow health...
+                                Skipping Commons id=0 (future commons) because the game is not in progress
                                 Cow health has been updated!""";
                 assertEquals(expected, job.getLog());
         }


### PR DESCRIPTION
Closes #250.

## What this does

**1. End date is required by the backend (not just the form)**
- `Commons.lastDate` now has `@Column(nullable = false)`, with liquibase migration `002_require_last_date_on_commons.json` that backfills any NULL `LAST_DATE` (to `COALESCE(STARTING_DATE, CURRENT_TIMESTAMP)`) before adding the NOT NULL constraint
- `POST /api/commons/new` and `PUT /api/commons/update` return 400 if either date is missing or if the end date is not strictly after the start date

**2. Every job is gated on "game in progress"**
- `Commons.gameInProgress(now)`: the **starting date is the first day of play and the last date is the last day of play** — the game runs from 00:00 local time on the starting date (inclusive) up to midnight at the end of the last date
- New shared `CommonsGate.shouldProcess(...)` used by all seven jobs that touch a commons: MilkTheCowsJob(+Ind), UpdateCowHealthJob(+Ind), RecordCommonStatsJob, InstructorReportJob(+SingleCommons), and SetCowHealthJob. Skipped commons are logged (`Skipping Commons id=N (name) because the game is not in progress`)

**3. Ended games are auto-hidden**
- When the gate encounters a commons whose end date has passed and which isn't hidden yet, it sets `hidden=true` and saves — so with the scheduled jobs running several times a day, ended games disappear on their own

**4. Form changes**
- Default end date is now 4 months after the start date (was 1 month)
- Tooltips over the Starting Date and Last Date fields explain the first-day-of-play / last-day-of-play semantics
- The form validates that the end date is strictly after the start date ("Last date must be after starting date"), and the previously blank invalid-date feedback now has messages
- Bug fix: the edit form now strips the timestamp suffix from `lastDate` (previously only `startingDate` was stripped, so the Last Date field rendered blank when editing)

## Verification

- Backend: 278 unit tests pass; jacoco 100% on all changed classes; pitest 100% on changed classes; migration applies cleanly (verified via CommonsIT with liquibase logs, plus the dokku deploy + smoke test)
- Frontend: 643 tests pass at 100% line/branch coverage; Stryker 100% (179/179) on CommonsForm.jsx; prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)