### PR TITLE
Hotfix: make lib-jobs migration's FK drop idempotent

### DIFF
--- a/src/main/resources/db/migration/changes/004_migrate_jobs_to_lib_jobs.json
+++ b/src/main/resources/db/migration/changes/004_migrate_jobs_to_lib_jobs.json
@@ -2,16 +2,47 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "004-migrate-jobs-to-lib-jobs",
+        "id": "004-migrate-jobs-to-lib-jobs-drop-fk",
         "author": "pc",
-        "comment": "Migrate the jobs table to the lib-jobs library schema: creator denormalized to created_by_email (no backfill; UI tolerates null), and generic scope_type/scope_id columns added (unused by this app today; see lib-jobs DESIGN.md 3.4/3.7)",
+        "comment": "Migrate the jobs table to the lib-jobs library schema: drop the FK from jobs.created_by_id to users, since lib-jobs denormalizes the creator to created_by_email instead. Guarded by a precondition since some environments' jobs table was never created with this constraint under this name.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "foreignKeyConstraintExists": {
+              "foreignKeyTableName": "jobs",
+              "foreignKeyName": "FK_JOBS_USERS"
+            }
+          }
+        ],
         "changes": [
           {
             "dropForeignKeyConstraint": {
               "baseTableName": "jobs",
               "constraintName": "FK_JOBS_USERS"
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "004-migrate-jobs-to-lib-jobs-add-columns",
+        "author": "pc",
+        "comment": "Migrate the jobs table to the lib-jobs library schema: creator denormalized to created_by_email (no backfill; UI tolerates null), and generic scope_type/scope_id columns added (unused by this app today; see lib-jobs DESIGN.md 3.4/3.7)",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "not": [
+              {
+                "columnExists": {
+                  "tableName": "jobs",
+                  "columnName": "created_by_email"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
           {
             "addColumn": {
               "tableName": "jobs",


### PR DESCRIPTION
## Summary
- Fixes a production migration failure introduced by #270: `liquibase.exception.DatabaseException: ERROR: constraint "fk_jobs_users" of relation "jobs" does not exist` on `ALTER TABLE public.jobs DROP CONSTRAINT FK_JOBS_USERS`.
- Splits the `004-migrate-jobs-to-lib-jobs` changeset into two idempotent changesets: one that drops `FK_JOBS_USERS` only if it exists (precondition + `onFail: MARK_RAN`), and one that adds the new lib-jobs columns only if they aren't already present — both following the precondition idiom already used elsewhere in this changelog (e.g. `005_add_course_id_to_commons.json`).

## Test plan
- [x] `mvn verify` passes locally (370+ tests, 100% JaCoCo coverage)
- [x] Verified against a real Postgres 15 instance via `liquibase-maven-plugin`:
  - Fresh DB (normal path, FK exists): FK dropped, columns added, matches prior behavior.
  - Simulated broken DB (FK manually dropped out-of-band, reproducing the exact reported error on the raw `ALTER TABLE ... DROP CONSTRAINT FK_JOBS_USERS` statement): drop-fk changeset gracefully marks itself as ran via the precondition, add-columns changeset still runs normally. Final schema identical in both cases.
  - Re-running `update` afterward is a clean no-op in both scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)