### PR TITLE
Change "Commons" in user facing terminology to "Game" (closes #271)

### DIFF
--- a/frontend/src/main/components/Commons/AdminCommonsCard.jsx
+++ b/frontend/src/main/components/Commons/AdminCommonsCard.jsx
@@ -47,14 +47,14 @@ export default function AdminCommonsCard({ commonItem, currentUser }) {
       <Modal.Header closeButton>
         <Modal.Title>Confirm Deletion</Modal.Title>
       </Modal.Header>
-      <Modal.Body>Are you sure you want to delete this commons?</Modal.Body>
+      <Modal.Body>Are you sure you want to delete this game?</Modal.Body>
       <Modal.Footer>
         <Button
           variant="secondary"
           data-testid={`AdminCommonsCard-Modal-Cancel-${commons.id}`}
           onClick={() => setShowModal(false)}
         >
-          Keep this Commons
+          Keep this Game
         </Button>
         <Button
           variant="danger"

--- a/frontend/src/main/components/Commons/CommonsCard.jsx
+++ b/frontend/src/main/components/Commons/CommonsCard.jsx
@@ -27,7 +27,7 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
                   ) {
                     // Stryker disable all: unable to read alert text in tests
                     alert(
-                      "This commons has not started yet and cannot be joined.\nThe starting date is " +
+                      "This game has not started yet and cannot be joined.\nThe starting date is " +
                         parseInt(commons.startingDate.substring(5, 7)) +
                         "/" +
                         parseInt(commons.startingDate.substring(8, 10)) +

--- a/frontend/src/main/components/Commons/CommonsForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsForm.jsx
@@ -129,7 +129,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
       >
         <Col className="" md={6}>
           <Form.Group className="mb-3">
-            <Form.Label htmlFor="name">Commons Name</Form.Label>
+            <Form.Label htmlFor="name">Game Name</Form.Label>
             <OverlayTrigger
               placement="top"
               overlay={
@@ -145,7 +145,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                 type="text"
                 defaultValue={DefaultVals.name}
                 isInvalid={!!errors.name}
-                {...register("name", { required: "Commons name is required" })}
+                {...register("name", { required: "Game name is required" })}
               />
             </OverlayTrigger>
             <Form.Control.Feedback type="invalid">
@@ -289,7 +289,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
               overlay={
                 <Tooltip>
                   This number controls the rate at which cow health decreases
-                  when the number of cows in the commons is greater than the
+                  when the number of cows in the game is greater than the
                   effective carrying capacity. The way in which the number is
                   used depends on the selected Health Update Formulas below.
                 </Tooltip>
@@ -324,11 +324,10 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
               placement="bottom"
               overlay={
                 <Tooltip>
-                  This is the minimum carrying capacity for the commons; at
-                  least this many cows may graze in the commons regardless of
-                  the number of players. If this number is zero, then only the
-                  Capacity Per User is used to determine the actual carrying
-                  capacity.
+                  This is the minimum carrying capacity for the game; at least
+                  this many cows may graze in the game regardless of the number
+                  of players. If this number is zero, then only the Capacity Per
+                  User is used to determine the actual carrying capacity.
                 </Tooltip>
               }
               delay="100"
@@ -360,9 +359,9 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
               placement="bottom"
               overlay={
                 <Tooltip>
-                  When this number is greater than zero, the commons will be
-                  able to support at least this many cows per farmer; that is,
-                  the effective carrying capacity of the commons is the value of
+                  When this number is greater than zero, the game will be able
+                  to support at least this many cows per farmer; that is, the
+                  effective carrying capacity of the game is the value of
                   Carrying Capacity, or Capacity Per User times the number of
                   Farmers, whichever is greater. If this number is zero, then
                   the Carrying Capacity is fixed regardless of the number of
@@ -499,8 +498,8 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
               overlay={
                 <Tooltip>
                   When checked, regular users will have access to the chat for
-                  this commons. When unchecked, only admins can see the chat for
-                  this commons.
+                  this game. When unchecked, only admins can see the chat for
+                  this game.
                 </Tooltip>
               }
               delay="100"

--- a/frontend/src/main/components/Commons/CommonsList.jsx
+++ b/frontend/src/main/components/Commons/CommonsList.jsx
@@ -58,7 +58,7 @@ const CommonsList = (props) => {
                     { fontFamily: "Sancreek", paddingBottom: "10px" }
                   }
                 >
-                  Common's Name
+                  Game Name
                 </Col>
                 <Col sm={4}></Col>
               </Row>
@@ -88,7 +88,7 @@ const CommonsList = (props) => {
               }
               data-testid="commonsList-default-message"
             >
-              There are currently no commons to {defaultMessage}
+              There are currently no games to {defaultMessage}
             </Row>
           </Container>
         </Card.Subtitle>

--- a/frontend/src/main/components/Commons/CommonsSelect.jsx
+++ b/frontend/src/main/components/Commons/CommonsSelect.jsx
@@ -9,7 +9,7 @@ function CommonsSelect({
   return (
     <Form.Group className="mb-3">
       <Form.Text htmlFor="commons" className="fw-bold fs-5">
-        Commons
+        Game
       </Form.Text>
       <div className="ms-3" data-testid={`${testid}-CommonsSelect-div`}>
         {commons.map((object) => (

--- a/frontend/src/main/components/Jobs/InstructorReportSpecificCommonsForm.jsx
+++ b/frontend/src/main/components/Jobs/InstructorReportSpecificCommonsForm.jsx
@@ -32,7 +32,7 @@ function InstructorReportSpecificCommonsForm({ submitAction }) {
   };
 
   if (!commons || commons.length === 0) {
-    return <div>There are no commons on which to run this job.</div>;
+    return <div>There are no games on which to run this job.</div>;
   }
 
   if (selectedCommons === null) {
@@ -50,7 +50,7 @@ function InstructorReportSpecificCommonsForm({ submitAction }) {
       />
       <p>
         Click this button to generate an instructor report for the selected
-        commons.
+        game.
       </p>
       <Button
         type="submit"

--- a/frontend/src/main/components/Jobs/MilkCowsJobForm.jsx
+++ b/frontend/src/main/components/Jobs/MilkCowsJobForm.jsx
@@ -13,7 +13,7 @@ function MilkTheCowsForm({ submitAction, testid = "MilkTheCowsForm" }) {
     [],
   );
 
-  const allCommonsProp = { id: 0, name: "All Commons" };
+  const allCommonsProp = { id: 0, name: "All Games" };
 
   const commons = [allCommonsProp, ...commonsAll];
 
@@ -42,7 +42,7 @@ function MilkTheCowsForm({ submitAction, testid = "MilkTheCowsForm" }) {
     <Form onSubmit={handleSubmit(onSubmit)}>
       <Form.Group className="mb-3">
         <Form.Text htmlFor="description">
-          Milk the cows in a single or all commons.
+          Milk the cows in a single or all games.
         </Form.Text>
       </Form.Group>
 

--- a/frontend/src/main/components/Jobs/RecordCommonStatsForm.jsx
+++ b/frontend/src/main/components/Jobs/RecordCommonStatsForm.jsx
@@ -10,8 +10,8 @@ function RecordCommonStatsForm({
     <Form onSubmit={handleSubmit(submitAction)} data-testid={testid}>
       <Form.Group className="mb-3">
         <Form.Text>
-          Record statistics for all commons. This will create a CommonStats
-          record for each commons with current health and profit data.
+          Record statistics for all games. This will create a CommonStats record
+          for each game with current health and profit data.
         </Form.Text>
       </Form.Group>
       <Button type="submit" data-testid="RecordCommonStatsForm-Submit-Button">

--- a/frontend/src/main/components/Jobs/SetCowHealthForm.jsx
+++ b/frontend/src/main/components/Jobs/SetCowHealthForm.jsx
@@ -43,7 +43,7 @@ function SetCowHealthForm({
   };
 
   if (!commons || commons.length === 0) {
-    return <div>There are no commons on which to run this job.</div>;
+    return <div>There are no games on which to run this job.</div>;
   }
 
   if (selectedCommons === null) {
@@ -55,7 +55,7 @@ function SetCowHealthForm({
     <Form onSubmit={handleSubmit(onSubmit)}>
       <Form.Group className="mb-3">
         <Form.Text htmlFor="description">
-          Set the cow health for all cows in a single commons.
+          Set the cow health for all cows in a single game.
         </Form.Text>
       </Form.Group>
 

--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.jsx
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.jsx
@@ -13,7 +13,7 @@ function UpdateCowHealthForm({ submitAction, testid = "UpdateCowHealthForm" }) {
     [],
   );
 
-  const allCommonsProp = { id: 0, name: "All Commons" };
+  const allCommonsProp = { id: 0, name: "All Games" };
 
   const commons = [allCommonsProp, ...commonsAll];
 
@@ -41,7 +41,7 @@ function UpdateCowHealthForm({ submitAction, testid = "UpdateCowHealthForm" }) {
     <Form onSubmit={handleSubmit(onSubmit)}>
       <Form.Group className="mb-3">
         <Form.Text htmlFor="description">
-          Updated the cows' health in a single or all commons.
+          Updated the cows' health in a single or all games.
         </Form.Text>
       </Form.Group>
 

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -66,10 +66,10 @@ export default function AppNavbar({
                   data-testid="appnavbar-admin-dropdown"
                 >
                   <NavDropdown.Item href="/admin/createcommons">
-                    Create Commons
+                    Create Game
                   </NavDropdown.Item>
                   <NavDropdown.Item href="/admin/listcommonsv2">
-                    List Commons
+                    List Games
                   </NavDropdown.Item>
                   <NavDropdown.Item href="/admin/listcourses">
                     Courses

--- a/frontend/src/main/components/Reports/ReportTable.jsx
+++ b/frontend/src/main/components/Reports/ReportTable.jsx
@@ -26,7 +26,7 @@ export default function ReportTable({
       accessor: "id",
     },
     {
-      Header: "commonsId",
+      Header: "gameId",
       accessor: "commonsId",
       Cell: (props) => {
         return <div style={{ textAlign: "right" }}>{props.value}</div>;

--- a/frontend/src/main/components/UserProfileTable.jsx
+++ b/frontend/src/main/components/UserProfileTable.jsx
@@ -18,7 +18,7 @@ export default function UserProfileTable({ user }) {
           <td>{user.email}</td>
         </tr>
         <tr>
-          <th>Joined Commons</th>
+          <th>Joined Games</th>
           <td>{commonsString(user.commons)}</td>
         </tr>
         <tr>

--- a/frontend/src/main/pages/AdminAnnouncementsPage.jsx
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.jsx
@@ -50,7 +50,7 @@ export default function AdminAnnouncementsPage() {
       <div className="pt-2">
         <Row className="pt-5 pb-3" style={{ gap: "30px" }}>
           <Col md="auto">
-            <h2>Announcements for Commons: {commonsName}</h2>
+            <h2>Announcements for Game: {commonsName}</h2>
           </Col>
           <Col style={buttonStyle}>
             <Button

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.jsx
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.jsx
@@ -76,7 +76,7 @@ const AdminCreateAnnouncementsPage = () => {
 
   return (
     <BasicLayout>
-      <h2>Create Announcement for Commons {commonsName}</h2>
+      <h2>Create Announcement for Game {commonsName}</h2>
       <AnnouncementForm submitAction={submitAction} />
     </BasicLayout>
   );

--- a/frontend/src/main/pages/AdminCreateCommonsPage.jsx
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.jsx
@@ -16,7 +16,7 @@ const AdminCreateCommonsPage = () => {
   const onSuccess = (commons) => {
     toast(
       <div>
-        Commons successfully created!
+        Game successfully created!
         <br />
         {`id: ${commons.id}`}
         <br />
@@ -54,7 +54,7 @@ const AdminCreateCommonsPage = () => {
 
   return (
     <BasicLayout>
-      <h2>Create Commons</h2>
+      <h2>Create Game</h2>
       <CommonsForm submitAction={submitAction} />
     </BasicLayout>
   );

--- a/frontend/src/main/pages/AdminEditAnnouncementsPage.jsx
+++ b/frontend/src/main/pages/AdminEditAnnouncementsPage.jsx
@@ -89,7 +89,7 @@ const AdminEditAnnouncementsPage = () => {
 
   return (
     <BasicLayout>
-      <h2>Edit Announcement for Commons {commonsName}</h2>
+      <h2>Edit Announcement for Game {commonsName}</h2>
       <AnnouncementForm
         initialContents={announcement}
         submitAction={submitAction}

--- a/frontend/src/main/pages/AdminEditCommonsPage.jsx
+++ b/frontend/src/main/pages/AdminEditCommonsPage.jsx
@@ -53,7 +53,7 @@ export default function CommonsEditPage() {
   });
 
   const onSuccess = (_, commons) => {
-    toast(`Commons Updated - id: ${commons.id} name: ${commons.name}`);
+    toast(`Game Updated - id: ${commons.id} name: ${commons.name}`);
   };
 
   const mutation = useBackendMutation(
@@ -76,7 +76,7 @@ export default function CommonsEditPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit Commons</h1>
+        <h1>Edit Game</h1>
         {commons && (
           <CommonsForm
             initialCommons={commons}

--- a/frontend/src/main/pages/AdminJobsPage.jsx
+++ b/frontend/src/main/pages/AdminJobsPage.jsx
@@ -49,7 +49,7 @@ const AdminJobsPage = () => {
 
   const submitSetCowHealthJob = async (data) => {
     toast(
-      `Submitted Job: Set Cow Health (Commons: ${data.selectedCommonsName}, Health: ${data.healthValue})`,
+      `Submitted Job: Set Cow Health (Game: ${data.selectedCommonsName}, Health: ${data.healthValue})`,
     );
     SetCowHealthMutation.mutate(data);
   };
@@ -81,12 +81,12 @@ const AdminJobsPage = () => {
   // Stryker restore all
 
   const submitUpdateCowHealthJob = async (data) => {
-    if (data.selectedCommonsName === "All Commons") {
+    if (data.selectedCommonsName === "All Games") {
       toast("Submitted Job: Update Cow Health");
       UpdateCowHealthMutation.mutate();
     } else {
       toast(
-        `Submitted Job: Update Cow Health (Commons: ${data.selectedCommonsName})`,
+        `Submitted Job: Update Cow Health (Game: ${data.selectedCommonsName})`,
       );
       UpdateCowHealthSingleMutation.mutate(data);
     }
@@ -137,12 +137,12 @@ const AdminJobsPage = () => {
   // Stryker restore all
 
   const submitMilkTheCowsJob = async (data) => {
-    if (data.selectedCommonsName === "All Commons") {
+    if (data.selectedCommonsName === "All Games") {
       toast("Submitted Job: Milk The Cows!");
       MilkTheCowsMutation.mutate();
     } else {
       toast(
-        `Submitted Job: Milk The Cows! (Commons: ${data.selectedCommonsName})`,
+        `Submitted Job: Milk The Cows! (Game: ${data.selectedCommonsName})`,
       );
       MilkTheCowsSingleMutation.mutate(data);
     }
@@ -185,7 +185,7 @@ const AdminJobsPage = () => {
   // Stryker restore all
 
   const submitInstructorReportSpecificCommonsJob = async (data) => {
-    toast("Submitted Job: Instructor Report (Specific Commons)");
+    toast("Submitted Job: Instructor Report (Specific Game)");
     InstructorReportSpecificCommonsMutation.mutate(data);
   };
 
@@ -195,7 +195,7 @@ const AdminJobsPage = () => {
       form: <TestJobForm submitAction={submitTestJob} />,
     },
     {
-      name: "Set Cow Health for a Specific Commons",
+      name: "Set Cow Health for a Specific Game",
       form: <SetCowHealthForm submitAction={submitSetCowHealthJob} />,
     },
     {
@@ -215,7 +215,7 @@ const AdminJobsPage = () => {
       form: <InstructorReportForm submitAction={submitInstructorReportJob} />,
     },
     {
-      name: "Instructor Report (for specific commons)",
+      name: "Instructor Report (for specific game)",
       form: (
         <InstructorReportSpecificCommonsForm
           submitAction={submitInstructorReportSpecificCommonsJob}

--- a/frontend/src/main/pages/AdminListCommonPageV2.jsx
+++ b/frontend/src/main/pages/AdminListCommonPageV2.jsx
@@ -66,7 +66,7 @@ export default function AdminListCommonsPageV2() {
       <div className="pt-2">
         <Row className="pt-5 page-header align-items-center">
           <Col md={3}>
-            <h2 style={{ margin: 0 }}>Commons</h2>
+            <h2 style={{ margin: 0 }}>Games</h2>
           </Col>
           <Col md={6}>
             <div className="search-container">

--- a/frontend/src/main/pages/AdminViewPlayPage.jsx
+++ b/frontend/src/main/pages/AdminViewPlayPage.jsx
@@ -100,7 +100,7 @@ const AdminViewPlayPage = () => {
               This is a Admin Feature for <strong>{admin_name}</strong>
               <br />
               Visiting Farmer <strong>{visiting_user}</strong>'s Play Page for
-              common <strong>{visiting_commons}</strong> in Read Only Mode.
+              game <strong>{visiting_commons}</strong> in Read Only Mode.
             </Card.Title>
           </Card.Body>
         </Card>

--- a/frontend/src/main/pages/ChatHistoryPage.jsx
+++ b/frontend/src/main/pages/ChatHistoryPage.jsx
@@ -140,9 +140,9 @@ const ChatHistoryPage = ({ readOnly = false, isAdmin = false }) => {
         <div className="d-flex flex-column mb-3">
           <div className="d-flex justify-content-between align-items-center">
             <span className="text-muted">
-              Commons #{commonsId} {readOnly && "• Admin Read Only"}
+              Game #{commonsId} {readOnly && "• Admin Read Only"}
             </span>
-            <span className="text-muted">Commons #{commonsId}</span>
+            <span className="text-muted">Game #{commonsId}</span>
           </div>
 
           {isAdmin && (
@@ -184,7 +184,7 @@ const ChatHistoryPage = ({ readOnly = false, isAdmin = false }) => {
           )}
           {!isInitialLoading && messages.length === 0 && (
             <div className="text-center text-muted my-3">
-              No messages available for this commons.
+              No messages available for this game.
             </div>
           )}
           {messages.map((message) => (

--- a/frontend/src/main/pages/HomePage.jsx
+++ b/frontend/src/main/pages/HomePage.jsx
@@ -74,7 +74,7 @@ export default function HomePage({ hour = null }) {
     navigate("/play/" + id);
   };
 
-  //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
+  //create a list of commons that the user hasn't joined for use in the "Join A New Game" list.
   const commonsNotJoinedList = filterCommonsNotJoinedAndNotHidden(
     commons,
     commonsJoined,
@@ -100,7 +100,7 @@ export default function HomePage({ hour = null }) {
             <Col sm>
               <CommonsList
                 commonList={commonsNotJoinedList}
-                title="Join A New Commons"
+                title="Join A New Game"
                 buttonText={"Join"}
                 buttonLink={mutation.mutate}
               />
@@ -109,7 +109,7 @@ export default function HomePage({ hour = null }) {
             <Col sm>
               <CommonsList
                 commonList={commonsJoined}
-                title="Visit A Commons"
+                title="Visit A Game"
                 buttonText={"Visit"}
                 buttonLink={visitButtonClick}
               />

--- a/frontend/src/main/pages/PlayPage.jsx
+++ b/frontend/src/main/pages/PlayPage.jsx
@@ -192,16 +192,16 @@ export default function PlayPage() {
     >
       <BasicLayout>
         <Container>
-          {!commonsPlus && <h1>This commons does not exist!</h1>}
+          {!commonsPlus && <h1>This game does not exist!</h1>}
           {deniedAccess && (
             <h1>
-              You do not currently have access to this Commons. Please contact
-              your instructor if you think this is an error
+              You do not currently have access to this Game. Please contact your
+              instructor if you think this is an error
             </h1>
           )}
-          {notallowed && <h1>You have yet to join this commons!</h1>}
+          {notallowed && <h1>You have yet to join this game!</h1>}
           {hidden && (
-            <h1>This commons has been hidden by the site administrator.</h1>
+            <h1>This game has been hidden by the site administrator.</h1>
           )}
 
           {allowed && !!currentUser && (

--- a/frontend/src/tests/components/Commons/AdminCommonsCard.test.jsx
+++ b/frontend/src/tests/components/Commons/AdminCommonsCard.test.jsx
@@ -282,7 +282,7 @@ describe("AdminCommonsCard tests", () => {
 
     expect(screen.getByText("Confirm Deletion")).toBeInTheDocument();
     expect(
-      screen.getByText("Are you sure you want to delete this commons?"),
+      screen.getByText("Are you sure you want to delete this game?"),
     ).toBeInTheDocument();
   });
 
@@ -325,7 +325,7 @@ describe("AdminCommonsCard tests", () => {
 
     axiosMock
       .onDelete("/api/commons", { params: { id: 1 } })
-      .reply(200, "Commons with id 1 was deleted");
+      .reply(200, "Game with id 1 was deleted");
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -350,7 +350,7 @@ describe("AdminCommonsCard tests", () => {
     fireEvent.click(confirmDeleteButton);
 
     await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith("Commons with id 1 was deleted");
+      expect(mockToast).toHaveBeenCalledWith("Game with id 1 was deleted");
     });
 
     expect(axiosMock.history.delete.length).toBe(1);
@@ -598,7 +598,7 @@ describe("AdminCommonsCard tests", () => {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Keep this Commons")).toBeInTheDocument();
+    expect(screen.getByText("Keep this Game")).toBeInTheDocument();
     expect(screen.getByText("Permanently Delete")).toBeInTheDocument();
   });
 
@@ -785,7 +785,7 @@ describe("AdminCommonsCard tests", () => {
 
     axiosMock
       .onDelete("/api/commons", { params: { id: 1 } })
-      .reply(200, "Commons with id 1 was deleted");
+      .reply(200, "Game with id 1 was deleted");
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Commons/CommonsForm.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.jsx
@@ -42,7 +42,7 @@ describe("CommonsForm tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByText(/Commons Name/)).toBeInTheDocument();
+    expect(await screen.findByText(/Game Name/)).toBeInTheDocument();
 
     [
       /Starting Balance/,
@@ -99,7 +99,7 @@ describe("CommonsForm tests", () => {
     //Check default empty field
     fireEvent.click(submitButton);
     expect(
-      await screen.findByText("Commons name is required"),
+      await screen.findByText("Game name is required"),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Degradation rate is required"),

--- a/frontend/src/tests/components/Commons/CommonsList.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsList.test.jsx
@@ -20,7 +20,7 @@ describe("CommonsList tests", () => {
     const subtitle_name = screen.getByTestId("commonsList-subtitle-name");
     expect(subtitle_name).toBeInTheDocument();
     expect(typeof subtitle_name.textContent).toBe("string");
-    expect(subtitle_name.textContent).toEqual("Common's Name");
+    expect(subtitle_name.textContent).toEqual("Game Name");
 
     const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
     expect(subtitle_id).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe("CommonsList tests", () => {
     const subtitle_name = screen.getByTestId("commonsList-subtitle-name");
     expect(subtitle_name).toBeInTheDocument();
     expect(typeof subtitle_name.textContent).toBe("string");
-    expect(subtitle_name.textContent).toEqual("Common's Name");
+    expect(subtitle_name.textContent).toEqual("Game Name");
 
     const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
     expect(subtitle_id).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe("CommonsList tests", () => {
     expect(subtitle_name).toBeInTheDocument();
     expect(typeof subtitle_name.textContent).toBe("string");
     expect(subtitle_name.textContent).toEqual(
-      "There are currently no commons to join",
+      "There are currently no games to join",
     );
     expect(subtitle_name).toHaveStyle("justify-content: center;");
 
@@ -148,7 +148,7 @@ describe("CommonsList tests", () => {
     expect(subtitle_name).toBeInTheDocument();
     expect(typeof subtitle_name.textContent).toBe("string");
     expect(subtitle_name.textContent).toEqual(
-      "There are currently no commons to visit",
+      "There are currently no games to visit",
     );
     expect(subtitle_name).toHaveStyle("justify-content: center;");
 

--- a/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.jsx
+++ b/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.jsx
@@ -32,7 +32,7 @@ describe("InstructorReportSpecificCommonsForm tests", () => {
     );
 
     expect(
-      await screen.findByText("There are no commons on which to run this job."),
+      await screen.findByText("There are no games on which to run this job."),
     ).toBeInTheDocument();
   });
 
@@ -60,7 +60,7 @@ describe("InstructorReportSpecificCommonsForm tests", () => {
     fireEvent.click(commonsRadio);
 
     expect(
-      screen.queryByText("There are no commons on which to run this job."),
+      screen.queryByText("There are no games on which to run this job."),
     ).not.toBeInTheDocument();
 
     const submitButton = screen.getByTestId(

--- a/frontend/src/tests/components/Jobs/RecordCommonStatsForm.test.jsx
+++ b/frontend/src/tests/components/Jobs/RecordCommonStatsForm.test.jsx
@@ -24,7 +24,7 @@ describe("RecordCommonStatsForm tests", () => {
       </QueryClientProvider>,
     );
     expect(
-      screen.getByText(/Record statistics for all commons/i),
+      screen.getByText(/Record statistics for all games/i),
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("RecordCommonStatsForm-Submit-Button"),
@@ -107,7 +107,7 @@ describe("RecordCommonStatsForm tests", () => {
       </QueryClientProvider>,
     );
     expect(
-      screen.getByText(/Record statistics for all commons/i),
+      screen.getByText(/Record statistics for all games/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/This will create a CommonStats/i),

--- a/frontend/src/tests/components/Jobs/SetCowHealthForm.test.jsx
+++ b/frontend/src/tests/components/Jobs/SetCowHealthForm.test.jsx
@@ -32,7 +32,7 @@ describe("SetCowHealthForm tests", () => {
     );
 
     expect(
-      await screen.findByText("There are no commons on which to run this job."),
+      await screen.findByText("There are no games on which to run this job."),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -44,8 +44,8 @@ describe("AppNavbar tests", () => {
     const adminMenu = screen.getByTestId("appnavbar-admin-dropdown");
     expect(adminMenu).toBeInTheDocument();
     fireEvent.click(screen.getByText("Admin"));
-    expect(await screen.findByText("List Commons")).toBeInTheDocument();
-    expect(screen.queryByText("List Commons V2")).not.toBeInTheDocument();
+    expect(await screen.findByText("List Games")).toBeInTheDocument();
+    expect(screen.queryByText("List Games V2")).not.toBeInTheDocument();
   });
 
   test("renders H2Console and Swagger links correctly", async () => {

--- a/frontend/src/tests/components/Reports/ReportTable.test.jsx
+++ b/frontend/src/tests/components/Reports/ReportTable.test.jsx
@@ -42,7 +42,7 @@ describe("ReportTable tests", () => {
     ];
     const expectedHeaders = [
       "id",
-      "commonsId",
+      "gameId",
       "Name",
       "Num Users",
       "Num Cows",

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.jsx
@@ -76,7 +76,7 @@ describe("AdminAnnouncementsPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Announcements for Commons: Sample Commons"),
+      await screen.findByText("Announcements for Game: Sample Commons"),
     ).toBeInTheDocument();
 
     const headerRow = container.querySelector(".row.pt-5.pb-3");
@@ -93,7 +93,7 @@ describe("AdminAnnouncementsPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Announcements for Commons: Sample Commons"),
+      await screen.findByText("Announcements for Game: Sample Commons"),
     ).toBeInTheDocument();
     expect(
       await screen.findByText(firstAnnouncement.announcementText),
@@ -110,7 +110,7 @@ describe("AdminAnnouncementsPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Announcements for Commons: Sample Commons"),
+      await screen.findByText("Announcements for Game: Sample Commons"),
     ).toBeInTheDocument();
     const createButton = screen.getByText("Create Announcement");
     expect(createButton).toHaveAttribute(
@@ -155,7 +155,7 @@ describe("AdminAnnouncementsPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Announcements for Commons: Sample Commons"),
+      await screen.findByText("Announcements for Game: Sample Commons"),
     ).toBeInTheDocument();
     expect(
       screen.queryByTestId(`${testId}-cell-row-0-col-id`),

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.jsx
@@ -75,7 +75,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
 
     const heading = await screen.findByRole("heading", { level: 2 });
     expect(heading).toHaveTextContent(
-      "Create Announcement for Commons Sample Commons",
+      "Create Announcement for Game Sample Commons",
     );
   });
 
@@ -228,7 +228,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
 
     const heading = await screen.findByRole("heading", { level: 2 });
     expect(heading).toHaveTextContent(
-      "Create Announcement for Commons Sample Commons",
+      "Create Announcement for Game Sample Commons",
     );
 
     const startDateField = screen.getByTestId("AnnouncementForm-startDate");

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.jsx
@@ -63,7 +63,7 @@ describe("AdminCreateCommonsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByText("Create Commons")).toBeInTheDocument();
+    expect(await screen.findByText("Create Game")).toBeInTheDocument();
   });
 
   test("When you fill in form and click submit, the right things happens", async () => {
@@ -91,9 +91,9 @@ describe("AdminCreateCommonsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByText("Create Commons")).toBeInTheDocument();
+    expect(await screen.findByText("Create Game")).toBeInTheDocument();
 
-    const commonsNameField = screen.getByLabelText("Commons Name");
+    const commonsNameField = screen.getByLabelText("Game Name");
     const startingBalanceField = screen.getByLabelText("Starting Balance");
     const cowPriceField = screen.getByLabelText("Cow Price");
     const milkPriceField = screen.getByLabelText("Milk Price");
@@ -157,7 +157,7 @@ describe("AdminCreateCommonsPage tests", () => {
 
     expect(mockToast).toBeCalledWith(
       <div>
-        Commons successfully created!
+        Game successfully created!
         <br />
         id: 5
         <br />

--- a/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.jsx
@@ -83,7 +83,7 @@ describe("AdminEditAnnouncementsPage tests", () => {
 
     const heading = await screen.findByRole("heading", { level: 2 });
     expect(heading).toHaveTextContent(
-      "Edit Announcement for Commons Sample Commons",
+      "Edit Announcement for Game Sample Commons",
     );
   });
 
@@ -272,7 +272,7 @@ describe("AdminEditAnnouncementsPage tests", () => {
 
     const heading = await screen.findByRole("heading", { level: 2 });
     expect(heading).toHaveTextContent(
-      "Edit Announcement for Commons Sample Commons",
+      "Edit Announcement for Game Sample Commons",
     );
 
     const startDateField = await screen.findByTestId(

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.jsx
@@ -111,9 +111,9 @@ describe("AdminEditCommonsPage tests", () => {
         </QueryClientProvider>,
       );
 
-      expect(await screen.findByLabelText(/Commons Name/)).toBeInTheDocument();
+      expect(await screen.findByLabelText(/Game Name/)).toBeInTheDocument();
 
-      const nameField = screen.getByLabelText(/Commons Name/);
+      const nameField = screen.getByLabelText(/Game Name/);
       const startingBalanceField = screen.getByLabelText(/Starting Balance/);
       const cowPriceField = screen.getByLabelText(/Cow Price/);
       const milkPriceField = screen.getByLabelText(/Milk Price/);
@@ -153,9 +153,9 @@ describe("AdminEditCommonsPage tests", () => {
         </QueryClientProvider>,
       );
 
-      expect(await screen.findByLabelText(/Commons Name/)).toBeInTheDocument();
+      expect(await screen.findByLabelText(/Game Name/)).toBeInTheDocument();
 
-      const nameField = screen.getByLabelText(/Commons Name/);
+      const nameField = screen.getByLabelText(/Game Name/);
       const startingBalanceField = screen.getByLabelText(/Starting Balance/);
       const cowPriceField = screen.getByLabelText(/Cow Price/);
       const milkPriceField = screen.getByLabelText(/Milk Price/);
@@ -211,7 +211,7 @@ describe("AdminEditCommonsPage tests", () => {
 
       await waitFor(() => expect(mockToast).toHaveBeenCalled());
       expect(mockToast).toBeCalledWith(
-        "Commons Updated - id: 5 name: Phill's Commons",
+        "Game Updated - id: 5 name: Phill's Commons",
       );
       expect(mockNavigate).toBeCalledWith({
         to: "/admin/listcommonsv2?focus=5",

--- a/frontend/src/tests/pages/AdminJobsPage.test.jsx
+++ b/frontend/src/tests/pages/AdminJobsPage.test.jsx
@@ -61,7 +61,7 @@ describe("AdminJobsPage tests", () => {
 
     expect(await screen.findByText("Test Job")).toBeInTheDocument();
     expect(
-      await screen.findByText("Set Cow Health for a Specific Commons"),
+      await screen.findByText("Set Cow Health for a Specific Game"),
     ).toBeInTheDocument();
     expect(await screen.findByText("Update Cow Health")).toBeInTheDocument();
     expect(await screen.findByText("Milk The Cows")).toBeInTheDocument();
@@ -120,7 +120,7 @@ describe("AdminJobsPage tests", () => {
     );
 
     const setCowHealthButton = await screen.findByText(
-      "Set Cow Health for a Specific Commons",
+      "Set Cow Health for a Specific Game",
     );
     expect(setCowHealthButton).toBeInTheDocument();
     setCowHealthButton.click();
@@ -147,7 +147,7 @@ describe("AdminJobsPage tests", () => {
     });
 
     expect(mockToast).toHaveBeenCalledWith(
-      `Submitted Job: Set Cow Health (Commons: Anika's Commons, Health: 10)`,
+      `Submitted Job: Set Cow Health (Game: Anika's Commons, Health: 10)`,
     );
   });
 
@@ -194,7 +194,7 @@ describe("AdminJobsPage tests", () => {
     });
 
     expect(mockToast).toHaveBeenCalledWith(
-      `Submitted Job: Update Cow Health (Commons: Anika's Commons)`,
+      `Submitted Job: Update Cow Health (Game: Anika's Commons)`,
     );
   });
 
@@ -280,7 +280,7 @@ describe("AdminJobsPage tests", () => {
     });
 
     expect(mockToast).toHaveBeenCalledWith(
-      `Submitted Job: Milk The Cows! (Commons: Anika's Commons)`,
+      `Submitted Job: Milk The Cows! (Game: Anika's Commons)`,
     );
   });
 
@@ -372,7 +372,7 @@ describe("AdminJobsPage tests", () => {
     );
 
     // assert
-    const label = "Instructor Report (for specific commons)";
+    const label = "Instructor Report (for specific game)";
     expect(await screen.findByText(label)).toBeInTheDocument();
 
     const InstructorReportJobButton = screen.getByText(label);
@@ -381,7 +381,7 @@ describe("AdminJobsPage tests", () => {
 
     await waitFor(() =>
       expect(
-        screen.queryByText("There are no commons on which to run this job."),
+        screen.queryByText("There are no games on which to run this job."),
       ).not.toBeInTheDocument(),
     );
 
@@ -401,7 +401,7 @@ describe("AdminJobsPage tests", () => {
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
-        "Submitted Job: Instructor Report (Specific Commons)",
+        "Submitted Job: Instructor Report (Specific Game)",
       );
     });
   });

--- a/frontend/src/tests/pages/AdminListCommonsPageV2.test.jsx
+++ b/frontend/src/tests/pages/AdminListCommonsPageV2.test.jsx
@@ -67,12 +67,12 @@ describe("AdminListCommonPageV2 tests", () => {
     );
 
     // Existing assertions
-    expect(screen.getByText("Commons")).toBeInTheDocument();
+    expect(screen.getByText("Games")).toBeInTheDocument();
     expect(screen.getByText("Download All Stats")).toBeInTheDocument();
 
     // ✅ Stryker-killers for style mutants:
-    // 1) <h2 style={{ margin: 0 }}>Commons</h2>
-    const heading = screen.getByRole("heading", { name: "Commons" });
+    // 1) <h2 style={{ margin: 0 }}>Games</h2>
+    const heading = screen.getByRole("heading", { name: "Games" });
     expect(heading).toHaveStyle("margin: 0px");
 
     // 2) Download All Stats button style={{ borderRadius: "30px", padding: "10px 20px" }}
@@ -97,7 +97,7 @@ describe("AdminListCommonPageV2 tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByText("Commons")).toBeInTheDocument();
+    expect(screen.getByText("Games")).toBeInTheDocument();
     expect(screen.getByText("Download All Stats")).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/pages/AdminViewPlayPage.test.jsx
+++ b/frontend/src/tests/pages/AdminViewPlayPage.test.jsx
@@ -209,7 +209,7 @@ describe("AdminViewPlayPage tests", () => {
       await screen.findByText(/This is a Admin Feature for/),
     ).toBeInTheDocument();
     expect(await screen.findByText(/Visiting Farmer/)).toBeInTheDocument();
-    expect(await screen.findByText(/Play Page for common/)).toBeInTheDocument();
+    expect(await screen.findByText(/Play Page for game/)).toBeInTheDocument();
 
     const bannerElement = screen.getByTestId(
       "adminviewplaypage-read-only-banner",
@@ -223,7 +223,7 @@ describe("AdminViewPlayPage tests", () => {
             `,
     );
     expect(bannerElement).toHaveTextContent(
-      "This is a Admin Feature for Phillip ConradVisiting Farmer 's Play Page for common Sample Commons in Read Only Mode.",
+      "This is a Admin Feature for Phillip ConradVisiting Farmer 's Play Page for game Sample Commons in Read Only Mode.",
     );
   });
 
@@ -266,7 +266,7 @@ describe("AdminViewPlayPage tests", () => {
       await screen.findByText(/This is a Admin Feature for/),
     ).toBeInTheDocument();
     expect(await screen.findByText(/Visiting Farmer/)).toBeInTheDocument();
-    expect(await screen.findByText(/Play Page for common/)).toBeInTheDocument();
+    expect(await screen.findByText(/Play Page for game/)).toBeInTheDocument();
   });
   test("renders when userCommons is truthy and commonsPlus is falsy", async () => {
     axiosMock
@@ -286,7 +286,7 @@ describe("AdminViewPlayPage tests", () => {
       await screen.findByText(/This is a Admin Feature for/),
     ).toBeInTheDocument();
     expect(await screen.findByText(/Visiting Farmer/)).toBeInTheDocument();
-    expect(await screen.findByText(/Play Page for common/)).toBeInTheDocument();
+    expect(await screen.findByText(/Play Page for game/)).toBeInTheDocument();
   });
   test("renders CardGroup when userCommons and commonsPlus are truthy", async () => {
     render(

--- a/frontend/src/tests/pages/ChatHistoryPage.test.jsx
+++ b/frontend/src/tests/pages/ChatHistoryPage.test.jsx
@@ -197,7 +197,7 @@ describe("ChatHistoryPage", () => {
 
     renderWithProviders();
     expect(
-      screen.getByText(/No messages available for this commons/i),
+      screen.getByText(/No messages available for this game/i),
     ).toBeInTheDocument();
 
     useInfiniteQuerySpy.mockRestore();
@@ -338,7 +338,7 @@ describe("ChatHistoryPage", () => {
     renderWithProviders();
     expect(screen.queryAllByTestId(/ChatMessageDisplay-/)).toHaveLength(0);
     expect(
-      screen.getByText(/No messages available for this commons/i),
+      screen.getByText(/No messages available for this game/i),
     ).toBeInTheDocument();
 
     useInfiniteQuerySpy.mockRestore();
@@ -794,7 +794,7 @@ describe("ChatHistoryPage", () => {
 
     renderWithProviders();
     expect(
-      screen.queryByText(/No messages available for this commons/i),
+      screen.queryByText(/No messages available for this game/i),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/tests/pages/PlayPage.test.jsx
+++ b/frontend/src/tests/pages/PlayPage.test.jsx
@@ -146,7 +146,7 @@ describe("PlayPage tests", () => {
 
     expect(
       screen.queryByText(
-        "This commons has been hidden by the site administrator.",
+        "This game has been hidden by the site administrator.",
       ),
     ).not.toBeInTheDocument();
   });
@@ -177,7 +177,7 @@ describe("PlayPage tests", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "This commons has been hidden by the site administrator.",
+          "This game has been hidden by the site administrator.",
         ),
       ).toBeInTheDocument();
     });
@@ -197,7 +197,7 @@ describe("PlayPage tests", () => {
 
     expect(await screen.findByTestId("buy-cow-button")).toBeInTheDocument();
     expect(
-      screen.queryByText("This commons does not exist!"),
+      screen.queryByText("This game does not exist!"),
     ).not.toBeInTheDocument();
 
     const buyCowButton = screen.getByTestId("buy-cow-button");
@@ -469,7 +469,7 @@ describe("PlayPage tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("You have yet to join this commons!"),
+        screen.getByText("You have yet to join this game!"),
       ).toBeInTheDocument();
     });
 
@@ -511,7 +511,7 @@ describe("PlayPage tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("You have yet to join this commons!"),
+        screen.getByText("You have yet to join this game!"),
       ).toBeInTheDocument();
     });
 
@@ -556,7 +556,7 @@ describe("PlayPage tests", () => {
     });
 
     expect(
-      screen.queryByText("You have yet to join this commons!"),
+      screen.queryByText("You have yet to join this game!"),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("commons-card")).toBeInTheDocument();
   });
@@ -596,7 +596,7 @@ describe("PlayPage tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("You have yet to join this commons!"),
+        screen.getByText("You have yet to join this game!"),
       ).toBeInTheDocument();
     });
 
@@ -639,9 +639,7 @@ describe("PlayPage tests", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(
-        screen.getByText("This commons does not exist!"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("This game does not exist!")).toBeInTheDocument();
     });
   });
 
@@ -688,7 +686,7 @@ describe("PlayPage tests", () => {
     renderPage();
 
     expect(
-      await screen.findByText("You have yet to join this commons!"),
+      await screen.findByText("You have yet to join this game!"),
     ).toBeInTheDocument();
 
     expect(
@@ -738,12 +736,12 @@ describe("PlayPage tests", () => {
 
     expect(
       await screen.findByText(
-        "You do not currently have access to this Commons. Please contact your instructor if you think this is an error",
+        "You do not currently have access to this Game. Please contact your instructor if you think this is an error",
       ),
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByText("You have yet to join this commons!"),
+      screen.queryByText("You have yet to join this game!"),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId("commonsPlay-title")).not.toBeInTheDocument();
     expect(screen.queryByTestId("ManageCows")).not.toBeInTheDocument();
@@ -772,7 +770,7 @@ describe("PlayPage tests", () => {
     expect(await screen.findByTestId("commonsPlay-title")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        "You do not currently have access to this Commons. Please contact your instructor if you think this is an error",
+        "You do not currently have access to this Game. Please contact your instructor if you think this is an error",
       ),
     ).not.toBeInTheDocument();
   });
@@ -797,7 +795,7 @@ describe("PlayPage tests", () => {
     expect(await screen.findByTestId("commonsPlay-title")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        "You do not currently have access to this Commons. Please contact your instructor if you think this is an error",
+        "You do not currently have access to this Game. Please contact your instructor if you think this is an error",
       ),
     ).not.toBeInTheDocument();
   });
@@ -825,7 +823,7 @@ describe("PlayPage tests", () => {
     expect(await screen.findByTestId("commonsPlay-title")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        "You do not currently have access to this Commons. Please contact your instructor if you think this is an error",
+        "You do not currently have access to this Game. Please contact your instructor if you think this is an error",
       ),
     ).not.toBeInTheDocument();
   });

--- a/frontend/src/tests/stories/pages/AdminAnnouncementsPageStories.test.jsx
+++ b/frontend/src/tests/stories/pages/AdminAnnouncementsPageStories.test.jsx
@@ -77,7 +77,7 @@ describe("Announcement page stories", () => {
     renderStory(CreateAnnouncementsStory);
 
     expect(
-      await screen.findByText("Create Announcement for Commons Sample Commons"),
+      await screen.findByText("Create Announcement for Game Sample Commons"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("AnnouncementForm-id")).not.toBeInTheDocument();
     expect(screen.getByTestId("AnnouncementForm-startDate")).toHaveValue("");
@@ -91,7 +91,7 @@ describe("Announcement page stories", () => {
     renderStory(EditAnnouncementsStory);
 
     expect(
-      await screen.findByText("Edit Announcement for Commons Sample Commons"),
+      await screen.findByText("Edit Announcement for Game Sample Commons"),
     ).toBeInTheDocument();
     expect(await screen.findByTestId("AnnouncementForm-id")).toHaveValue("1");
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -69,7 +69,7 @@ public class AnnouncementsController extends ApiController{
             Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
 
             if (!userCommonsLookup.isPresent()) {
-                return ResponseEntity.badRequest().body("Commons_id must exist.");
+                return ResponseEntity.badRequest().body("Game_id must exist.");
             }
         }
 
@@ -120,7 +120,7 @@ public class AnnouncementsController extends ApiController{
             Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
 
             if (!userCommonsLookup.isPresent()) {
-                return ResponseEntity.badRequest().body("Commons_id must exist.");
+                return ResponseEntity.badRequest().body("Game_id must exist.");
             }
         }
 
@@ -145,7 +145,7 @@ public class AnnouncementsController extends ApiController{
 
             if (!userCommonsLookup.isPresent()) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body("User is not a member of this commons.");
+                    .body("User is not a member of this game.");
             }
         }
 
@@ -192,7 +192,7 @@ public class AnnouncementsController extends ApiController{
             Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
 
             if (!userCommonsLookup.isPresent()) {
-                return ResponseEntity.badRequest().body("Commons_id must exist.");
+                return ResponseEntity.badRequest().body("Game_id must exist.");
             }
         }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -138,7 +138,7 @@ public class CommonsController extends ApiController {
     public CommonsPlus getCommonsPlusById(
             @Parameter(name="id") @RequestParam long id) throws JsonProcessingException {
                 CommonsPlus commonsPlus = commonsPlusBuilderService.toCommonsPlus(commonsRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id)));
+                .orElseThrow(() -> new EntityNotFoundException("Game", id)));
 
         return commonsPlus;
     }
@@ -222,7 +222,7 @@ public class CommonsController extends ApiController {
             @Parameter(name="id") @RequestParam Long id) throws JsonProcessingException {
 
         Commons commons = commonsRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+                .orElseThrow(() -> new EntityNotFoundException("Game", id));
 
         return commons;
     }
@@ -342,7 +342,7 @@ public class CommonsController extends ApiController {
         String username = u.getFullName();
 
         Commons joinedCommons = commonsRepository.findById(commonsId)
-                .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
+                .orElseThrow(() -> new EntityNotFoundException("Game", commonsId));
 
         if (joinedCommons.getCourseId() != null && !courseAccessService.isEligibleForCommons(u, joinedCommons)) {
             throw new CourseAccessDeniedException(commonsId);
@@ -387,11 +387,11 @@ public class CommonsController extends ApiController {
         }
 
         commonsRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+                .orElseThrow(() -> new EntityNotFoundException("Game", id));
 
         commonsRepository.deleteById(id);
 
-        String responseString = String.format("commons with id %d deleted", id);
+        String responseString = String.format("game with id %d deleted", id);
         return genericMessage(responseString);
 
     }
@@ -409,7 +409,7 @@ public class CommonsController extends ApiController {
 
         userCommonsRepository.delete(userCommons);
 
-        String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
+        String responseString = String.format("user with id %d deleted from game with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
 
         return genericMessage(responseString);
     }
@@ -422,7 +422,7 @@ public class CommonsController extends ApiController {
             @Parameter(name="request body") @RequestBody DashboardSettingsParams params
     ) {
         Commons commons = commonsRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+                .orElseThrow(() -> new EntityNotFoundException("Game", id));
 
         commons.setShowLeaderboard(params.isShowLeaderboard());
         commons.setShowOverviewSection(params.isShowOverviewSection());

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -69,7 +69,7 @@ public class UserCommonsController extends ApiController {
     User u = getCurrentUser().getUser();
     Long userId = u.getId();
     Commons commons = commonsRepository.findById(commonsId)
-        .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
+        .orElseThrow(() -> new EntityNotFoundException("Game", commonsId));
     ensureUserCanAccessCourseLinkedCommons(u, commons);
     UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
         .orElseThrow(
@@ -88,7 +88,7 @@ public class UserCommonsController extends ApiController {
         Long userId = u.getId();
 
         Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
-          ()->new EntityNotFoundException(Commons.class, commonsId));
+          ()->new EntityNotFoundException("Game", commonsId));
 
         ensureUserCanAccessCourseLinkedCommons(u, commons);
 
@@ -124,7 +124,7 @@ public class UserCommonsController extends ApiController {
         Long userId = u.getId();
 
         Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
-          ()->new EntityNotFoundException(Commons.class, commonsId));
+          ()->new EntityNotFoundException("Game", commonsId));
 
         ensureUserCanAccessCourseLinkedCommons(u, commons);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/errors/CommonsHiddenException.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/errors/CommonsHiddenException.java
@@ -2,6 +2,6 @@ package edu.ucsb.cs156.happiercows.errors;
 
 public class CommonsHiddenException extends RuntimeException {
     public CommonsHiddenException(Long id) {
-        super("Commons with id %d is hidden".formatted(id));
+        super("Game with id %d is hidden".formatted(id));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/errors/CourseAccessDeniedException.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/errors/CourseAccessDeniedException.java
@@ -2,6 +2,6 @@ package edu.ucsb.cs156.happiercows.errors;
 
 public class CourseAccessDeniedException extends RuntimeException {
     public CourseAccessDeniedException(Long commonsId) {
-        super("You are not enrolled in the course required to join commons with id %d".formatted(commonsId));
+        super("You are not enrolled in the course required to join game with id %d".formatted(commonsId));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/errors/EntityNotFoundException.java
@@ -6,6 +6,13 @@ public class EntityNotFoundException extends RuntimeException {
         .formatted(entityType.getSimpleName(), id.toString()));
   }
 
+  // Allows callers to supply a user-facing display name that differs from
+  // the entity's class name (e.g. "Game" for the Commons entity).
+  public EntityNotFoundException(String entityDisplayName, Object id) {
+    super("%s with id %s not found"
+        .formatted(entityDisplayName, id.toString()));
+  }
+
   public EntityNotFoundException(Class<?> entityType, String id1Label, Object id1, String id2Label, Object id2) {
     super("%s with %s %s and %s %s not found"
         .formatted(entityType.getSimpleName(),

--- a/src/main/java/edu/ucsb/cs156/happiercows/errors/NotEnrolledInCourseAssociatedWithCommonsException.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/errors/NotEnrolledInCourseAssociatedWithCommonsException.java
@@ -2,6 +2,6 @@ package edu.ucsb.cs156.happiercows.errors;
 
 public class NotEnrolledInCourseAssociatedWithCommonsException extends RuntimeException {
     public NotEnrolledInCourseAssociatedWithCommonsException() {
-        super("Not enrolled in course associated with commons");
+        super("Not enrolled in course associated with game");
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -503,7 +503,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         verify(announcementRepository, times(0)).findCurrentByCommonsId(commonsId, pageable);
 
         String responseString = response.getResponse().getContentAsString();
-        assertEquals("User is not a member of this commons.", responseString);
+        assertEquals("User is not a member of this game.", responseString);
     }
 
     @WithMockUser(roles = {"ADMIN"})

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -915,7 +915,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         Map<String, Object> responseMap = responseToJson(response);
 
-        assertEquals(responseMap.get("message"), "Commons with id 18 not found");
+        assertEquals(responseMap.get("message"), "Game with id 18 not found");
         assertEquals(responseMap.get("type"), "EntityNotFoundException");
     }
 
@@ -932,7 +932,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         Map<String, Object> responseMap = responseToJson(response);
 
-        assertEquals(responseMap.get("message"), "Commons with id 18 not found");
+        assertEquals(responseMap.get("message"), "Game with id 18 not found");
         assertEquals(responseMap.get("type"), "EntityNotFoundException");
     }
 
@@ -1042,7 +1042,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         Map<String, Object> responseMap = responseToJson(response);
 
-        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("message"), "Game with id 2 not found");
         assertEquals(responseMap.get("type"), "EntityNotFoundException");
     }
 
@@ -1071,7 +1071,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         Map<String, Object> responseMap = responseToJson(response);
         assertEquals("CourseAccessDeniedException", responseMap.get("type"));
         assertEquals(
-                "You are not enrolled in the course required to join commons with id 2",
+                "You are not enrolled in the course required to join game with id 2",
                 responseMap.get("message"));
     }
 
@@ -1222,7 +1222,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         String responseString = response.getResponse().getContentAsString();
 
-        String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
+        String expectedString = "{\"message\":\"game with id 2 deleted\"}";
 
         assertEquals(expectedString, responseString);
     }
@@ -1240,7 +1240,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         verify(commonsRepository, times(1)).findById(2L);
 
 
-        String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
+        String expectedString = "{\"message\":\"Game with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
 
         Map<String, Object> expectedJson = mapper.readValue(expectedString, new TypeReference<Map<String, Object>>() {
         });
@@ -1280,7 +1280,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         verify(userCommonsRepository, times(1)).delete(uc);
 
         String responseString = response.getResponse().getContentAsString();
-        String expectedString = "{\"message\":\"user with id 1 deleted from commons with id 2, 0 users remain\"}";
+        String expectedString = "{\"message\":\"user with id 1 deleted from game with id 2, 0 users remain\"}";
 
         assertEquals(responseString, expectedString);
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -185,7 +185,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         verify(courseAccessService, times(1)).isEligibleForCommons(eq(currentUser), eq(testCommons));
         verify(userCommonsRepository, times(0)).findByCommonsIdAndUserId(anyLong(), anyLong());
 
-        String expectedString = "{\"message\":\"Not enrolled in course associated with commons\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
+        String expectedString = "{\"message\":\"Not enrolled in course associated with game\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -225,7 +225,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         verify(commonsRepository, times(1)).findById(eq(1L));
         verify(userCommonsRepository, times(0)).findByCommonsIdAndUserId(anyLong(), anyLong());
 
-        String expectedString = "{\"message\":\"Commons with id 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        String expectedString = "{\"message\":\"Game with id 1 not found\",\"type\":\"EntityNotFoundException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -333,7 +333,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         verify(courseAccessService, times(1)).isEligibleForCommons(eq(currentUser), eq(testCommons));
         verify(userCommonsRepository, times(0)).findByCommonsIdAndUserId(anyLong(), anyLong());
 
-        String expectedString = "{\"message\":\"Not enrolled in course associated with commons\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
+        String expectedString = "{\"message\":\"Not enrolled in course associated with game\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -403,7 +403,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         verify(courseAccessService, times(1)).isEligibleForCommons(eq(currentUser), eq(testCommons));
         verify(userCommonsRepository, times(0)).findByCommonsIdAndUserId(anyLong(), anyLong());
 
-        String expectedString = "{\"message\":\"Not enrolled in course associated with commons\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
+        String expectedString = "{\"message\":\"Not enrolled in course associated with game\",\"type\":\"NotEnrolledInCourseAssociatedWithCommonsException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -454,7 +454,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .andExpect(status().is(404)).andReturn();
 
         // assert
-        String expectedString = "{\"message\":\"Commons with id 234 not found\",\"type\":\"EntityNotFoundException\"}";
+        String expectedString = "{\"message\":\"Game with id 234 not found\",\"type\":\"EntityNotFoundException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -472,7 +472,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .andExpect(status().is(404)).andReturn();
 
         // assert
-        String expectedString = "{\"message\":\"Commons with id 234 not found\",\"type\":\"EntityNotFoundException\"}";
+        String expectedString = "{\"message\":\"Game with id 234 not found\",\"type\":\"EntityNotFoundException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -606,7 +606,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .andExpect(status().is(400)).andReturn();
 
         // assert
-        String expectedString = "{\"message\":\"Commons with id 1 is hidden\",\"type\":\"CommonsHiddenException\"}";
+        String expectedString = "{\"message\":\"Game with id 1 is hidden\",\"type\":\"CommonsHiddenException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);
@@ -628,7 +628,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .andExpect(status().is(400)).andReturn();
 
         // assert
-        String expectedString = "{\"message\":\"Commons with id 1 is hidden\",\"type\":\"CommonsHiddenException\"}";
+        String expectedString = "{\"message\":\"Game with id 1 is hidden\",\"type\":\"CommonsHiddenException\"}";
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);

--- a/src/test/java/edu/ucsb/cs156/happiercows/web/CommonsWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/web/CommonsWebIT.java
@@ -25,7 +25,7 @@ public class CommonsWebIT extends WebTestCase {
         setupUser(true);
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Admin")).click();
-        page.getByText("Create Commons").click();
+        page.getByText("Create Game").click();
 
         
 
@@ -40,7 +40,7 @@ public class CommonsWebIT extends WebTestCase {
         setupUser(true);
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Admin")).click();
-        page.getByText("Create Commons").click();
+        page.getByText("Create Game").click();
     
         page.getByTestId("CommonsForm-name").fill("Web Test Commons");
         page.getByTestId("CommonsForm-Submit-Button").click();
@@ -51,7 +51,7 @@ public class CommonsWebIT extends WebTestCase {
         page.getByRole(
                         AriaRole.LINK,
                         new Page.GetByRoleOptions()
-                                .setName("List Commons")
+                                .setName("List Games")
                                 .setExact(true))
                 .click();
   
@@ -71,7 +71,7 @@ public class CommonsWebIT extends WebTestCase {
         // return to home page
         page.getByText("Happy Cows").click(); 
         
-        assertThat(page.getByText("There are currently no commons to join")).isVisible();
+        assertThat(page.getByText("There are currently no games to join")).isVisible();
     }
   
     @Test
@@ -79,9 +79,9 @@ public class CommonsWebIT extends WebTestCase {
         setupUser(true);
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Admin")).click();
-        page.getByText("Create Commons").click();
+        page.getByText("Create Game").click();
 
-        assertThat(page.getByText("Create Commons")).isVisible();
+        assertThat(page.getByText("Create Game")).isVisible();
 
         page.getByTestId("CommonsForm-name").fill("Web Test Commons 2");
         page.getByTestId("CommonsForm-startingBalance").fill("9000");
@@ -104,7 +104,7 @@ public class CommonsWebIT extends WebTestCase {
         page.getByRole(
                         AriaRole.LINK,
                         new Page.GetByRoleOptions()
-                                .setName("List Commons")
+                                .setName("List Games")
                                 .setExact(true))
                 .click();
         var commonsCard = page.getByTestId("AdminCommonsCard-1");

--- a/src/test/java/edu/ucsb/cs156/happiercows/web/DashboardWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/web/DashboardWebIT.java
@@ -25,7 +25,7 @@ public class DashboardWebIT extends WebTestCase {
         setupUser(true);
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Admin")).click();
-        page.getByText("Create Commons").click();
+        page.getByText("Create Game").click();
 
         page.getByTestId("CommonsForm-name").fill("Web Test Commons For Dashboard Defaults");
         page.getByTestId("CommonsForm-Submit-Button").click();
@@ -34,7 +34,7 @@ public class DashboardWebIT extends WebTestCase {
         page.getByRole(
                         AriaRole.LINK,
                         new Page.GetByRoleOptions()
-                                .setName("List Commons")
+                                .setName("List Games")
                                 .setExact(true))
                 .click();
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/web/UserCommonsWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/web/UserCommonsWebIT.java
@@ -27,7 +27,7 @@ public class UserCommonsWebIT extends WebTestCase {
 
         // Make the testing commons
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Admin")).click();
-        page.getByText("Create Commons").click();
+        page.getByText("Create Game").click();
 
         page.getByTestId("CommonsForm-name").fill("Web Test Commons");
         page.getByTestId("CommonsForm-Submit-Button").click();


### PR DESCRIPTION
## Summary
Closes #271. Every user-facing occurrence of "Commons" is now "Game" — labels, headings, buttons, tooltips, toast/error messages, nav items, and job-launcher admin forms. Internal code (class/file/variable/route names, DB tables/columns, API paths, Swagger docs, data-testids) is intentionally untouched, per the issue.

Notable scoping decisions:
- **Backend error messages that reach the UI** (`EntityNotFoundException`, `CommonsHiddenException`, `CourseAccessDeniedException`, `NotEnrolledInCourseAssociatedWithCommonsException`, and `AnnouncementsController`'s bad-request bodies) are included, since `useBackend.js` surfaces `response.data.message` directly via toast — these are genuinely user-visible. `EntityNotFoundException` gained a `String`-label overload so the `Commons` entity's not-found message can say "Game" without renaming the class.
- **Fixture/test data values** (e.g. a game literally named `"Anika's Commons"`) are left as-is — that's user-entered content, not app terminology.
- **Swagger/OpenAPI `@Operation` annotations, log statements, DB queries, and config property names** are out of scope — developer-facing, not end-user UX.
- `UserCommons` (the join-entity class) is left alone since it's a compound class name, not the standalone word "Commons".

## Test plan
- [x] Backend: `mvn verify` — 379/379 tests, 100% JaCoCo coverage
- [x] Frontend: 742/742 tests, 100% coverage (statements/branches/functions/lines), lint clean, prettier clean
- [x] Pitest on changed backend classes (controllers + error classes): 184/184 mutants killed, 100%
- [x] Stryker on changed frontend files (24 files touched): 988/988 mutants killed, 100%, 0 survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)