### PR TITLE
Guard FK constraint drops/renames in migration 007 with existence checks

### DIFF
--- a/src/main/resources/db/migration/changes/007_rename_commons_to_game.json
+++ b/src/main/resources/db/migration/changes/007_rename_commons_to_game.json
@@ -25,9 +25,57 @@
     },
     {
       "changeSet": {
-        "id": "007-rename-farmer-commons_id-column-and-fk",
+        "id": "007-drop-fk_farmer_commons",
         "author": "pc",
-        "comment": "Rename farmer.commons_id to farmer.game_id, and the FK_FARMER_COMMONS constraint to FK_FARMER_GAME.",
+        "comment": "Drop the FK_FARMER_COMMONS constraint on farmer.commons_id, if it exists under that name. Split out from the column rename below: some environments' constraint was never actually renamed to this name by migration 006 (e.g. because it was created outside of Liquibase originally, under a different name), so dropping it unconditionally as part of a combined changeset broke deploys with 'constraint does not exist' errors.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "foreignKeyConstraintExists": {
+              "foreignKeyTableName": "farmer",
+              "foreignKeyName": "FK_FARMER_COMMONS"
+            }
+          }
+        ],
+        "changes": [
+          {
+            "dropForeignKeyConstraint": {
+              "baseTableName": "farmer",
+              "constraintName": "FK_FARMER_COMMONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "007-drop-fk_user_commons_commons-on-farmer",
+        "author": "pc",
+        "comment": "Same as above, but for the original FK_USER_COMMONS_COMMONS name: covers environments where migration 006's rename of this constraint never took effect (its own precondition found no constraint under that exact name either), so the original name is still what's actually in the database.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "foreignKeyConstraintExists": {
+              "foreignKeyTableName": "farmer",
+              "foreignKeyName": "FK_USER_COMMONS_COMMONS"
+            }
+          }
+        ],
+        "changes": [
+          {
+            "dropForeignKeyConstraint": {
+              "baseTableName": "farmer",
+              "constraintName": "FK_USER_COMMONS_COMMONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "007-rename-farmer-commons_id-column",
+        "author": "pc",
+        "comment": "Rename farmer.commons_id to farmer.game_id.",
         "preConditions": [
           { "onFail": "MARK_RAN" },
           {
@@ -39,19 +87,41 @@
         ],
         "changes": [
           {
-            "dropForeignKeyConstraint": {
-              "baseTableName": "farmer",
-              "constraintName": "FK_FARMER_COMMONS"
-            }
-          },
-          {
             "renameColumn": {
               "tableName": "farmer",
               "oldColumnName": "commons_id",
               "newColumnName": "game_id",
               "columnDataType": "BIGINT"
             }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "007-add-fk_farmer_game",
+        "author": "pc",
+        "comment": "Add the FK_FARMER_GAME constraint on farmer.game_id, once the column rename above has happened and only if it isn't already present (whatever the old constraint on this column was named, and whether or not the drops above found anything to do, this is the state we actually care about).",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "columnExists": {
+              "tableName": "farmer",
+              "columnName": "game_id"
+            }
           },
+          {
+            "not": [
+              {
+                "foreignKeyConstraintExists": {
+                  "foreignKeyTableName": "farmer",
+                  "foreignKeyName": "FK_FARMER_GAME"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
           {
             "addForeignKeyConstraint": {
               "baseColumnNames": "game_id",
@@ -68,9 +138,33 @@
     },
     {
       "changeSet": {
-        "id": "007-rename-profits-commons_id-column-and-fk",
+        "id": "007-drop-fk_profits_user_commons",
         "author": "pc",
-        "comment": "Rename profits.commons_id to profits.game_id, and the FK_PROFITS_USER_COMMONS constraint to FK_PROFITS_FARMER.",
+        "comment": "Drop the FK_PROFITS_USER_COMMONS constraint on profits.commons_id, if it exists under that name. Split out from the column rename below, for the same reason as FK_FARMER_COMMONS above.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "foreignKeyConstraintExists": {
+              "foreignKeyTableName": "profits",
+              "foreignKeyName": "FK_PROFITS_USER_COMMONS"
+            }
+          }
+        ],
+        "changes": [
+          {
+            "dropForeignKeyConstraint": {
+              "baseTableName": "profits",
+              "constraintName": "FK_PROFITS_USER_COMMONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "007-rename-profits-commons_id-column",
+        "author": "pc",
+        "comment": "Rename profits.commons_id to profits.game_id.",
         "preConditions": [
           { "onFail": "MARK_RAN" },
           {
@@ -82,19 +176,41 @@
         ],
         "changes": [
           {
-            "dropForeignKeyConstraint": {
-              "baseTableName": "profits",
-              "constraintName": "FK_PROFITS_USER_COMMONS"
-            }
-          },
-          {
             "renameColumn": {
               "tableName": "profits",
               "oldColumnName": "commons_id",
               "newColumnName": "game_id",
               "columnDataType": "BIGINT"
             }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "007-add-fk_profits_farmer",
+        "author": "pc",
+        "comment": "Add the FK_PROFITS_FARMER constraint on profits(game_id, user_id), once the column rename above has happened and only if it isn't already present.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "columnExists": {
+              "tableName": "profits",
+              "columnName": "game_id"
+            }
           },
+          {
+            "not": [
+              {
+                "foreignKeyConstraintExists": {
+                  "foreignKeyTableName": "profits",
+                  "foreignKeyName": "FK_PROFITS_FARMER"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
           {
             "addForeignKeyConstraint": {
               "baseColumnNames": "game_id,user_id",


### PR DESCRIPTION
## Summary
Deploying `main` to a QA site fails with:
```
liquibase.exception.DatabaseException: ERROR: constraint "fk_farmer_commons" of relation "farmer" does not exist
[Failed SQL: (0) ALTER TABLE public.farmer DROP CONSTRAINT FK_FARMER_COMMONS]
```

The `farmer` and `profits` changesets in `007_rename_commons_to_game.json` each combine a `dropForeignKeyConstraint` + `renameColumn` + `addForeignKeyConstraint` into a single changeset gated only by a `columnExists` precondition. That means the constraint drop runs unconditionally as long as the column exists - regardless of whether a constraint by that exact name is actually present. On any database whose FK constraints weren't named exactly as `000_BASE_CHANGELOG` assumes (e.g. a schema that predates Liquibase adoption, or a constraint that migration 006 never successfully renamed), the deploy crashes.

## Fix
Split each combined changeset into separate drop / rename / add changesets, each with its own existence precondition - mirroring the pattern already used elsewhere in this same file (the `announcement`/`chat_message`/`commonstats`/`cowdeath`/`reports` renames) and in `004_migrate_jobs_to_lib_jobs.json`, whose own comment already documents this exact class of problem ("some environments' jobs table was never created with this constraint under this name"). The `farmer` table also gets a defensive drop attempt under the *original* `FK_USER_COMMONS_COMMONS` name, covering databases where migration 006's own rename never took effect.

I audited every migration file for this pattern (drop/rename operations not individually guarded by an existence precondition for the specific thing being touched) - these were the only two changesets with the gap.

## Verification
No Java code changed, so this doesn't touch anything JaCoCo/Pitest cover. Instead I verified against a real Postgres container (not just H2, since this class of bug is collation/history-dependent and H2 can mask it - see the umail-canonicalization PR for a concrete example of that divergence):

1. **Reproduced the exact reported error**: seeded a Postgres DB with schema through migration 005, renamed its FK constraints to simulate a database whose constraints were never named the way `000_BASE_CHANGELOG` assumes, then ran the *unfixed* migration chain - got the identical error message from the bug report.
2. **Confirmed the fix resolves it**: same seeded scenario, ran the *fixed* migration chain - completes without error, and `farmer`/`profits` end up with the correct `game_id` column and `FK_FARMER_GAME`/`FK_PROFITS_FARMER` constraints in place (the old, differently-named constraints just linger harmlessly as redundant duplicates enforcing the same relationship).
3. **Confirmed no regression on the two normal paths**: a fresh database running 000-007 in one shot, and a database with correctly-Liquibase-named constraints running through 005 then upgrading to 007 - both still complete cleanly with correctly-named constraints (no leftover duplicates).
4. Full backend test suite (`mvn verify`) passes.

## Deploy plan
Per offline discussion: this PR should be deployed to QA (and then production) *before* the umail-canonicalization hotfix PR, so the database gets into a consistent, correctly-named state first.

## Test plan
- [x] `mvn test` / `mvn verify` pass
- [x] Manually reproduced and fixed the reported error against real Postgres (see above)
- [ ] Deploy to QA and confirm the site comes up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)