### PR TITLE
Add page size control to students list on /admin/courses/:courseNum

### DIFF
--- a/frontend/src/main/components/OurTable.jsx
+++ b/frontend/src/main/components/OurTable.jsx
@@ -26,6 +26,15 @@ export default function OurTable({
 }) {
   const [pageIndex, setPageIndex] = React.useState(0);
   const pageSize = rest.pageSize || 10;
+
+  // If pageSize changes (e.g. the caller offers a page-size selector) while
+  // we're on a page beyond what the new size would produce, staying put
+  // would silently render an empty table - go back to the first page
+  // instead.
+  React.useEffect(() => {
+    setPageIndex(0);
+  }, [pageSize]);
+
   const appliedTableStyle = centered
     ? tableStyle
     : { ...tableStyle, margin: "0" };

--- a/frontend/src/main/components/Students/StudentsTable.jsx
+++ b/frontend/src/main/components/Students/StudentsTable.jsx
@@ -3,6 +3,7 @@ import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import StudentsForm from "main/components/Students/StudentsForm";
+import PageSizeSelector from "main/components/Utils/PageSizeSelector";
 import { useBackendMutation } from "main/utils/useBackend";
 import { formatTime } from "main/utils/dateUtils";
 import {
@@ -22,6 +23,7 @@ export default function StudentsTable({
   const [cellToDelete, setCellToDelete] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [studentToEdit, setStudentToEdit] = useState(null);
+  const [pageSize, setPageSize] = useState(20);
 
   const queryKey = [`/api/student/course/${courseId}`];
 
@@ -156,11 +158,17 @@ export default function StudentsTable({
 
   return (
     <>
+      <PageSizeSelector
+        value={pageSize}
+        onChange={setPageSize}
+        testid={`${testid}-page-size-selector`}
+      />
       <OurTable
         data={students}
         columns={columnsToDisplay}
         testid={testid}
         centered={false}
+        pageSize={pageSize}
       />
       {hasRole(currentUser, "ROLE_ADMIN") && editModal}
       {hasRole(currentUser, "ROLE_ADMIN") && studentsModal}

--- a/frontend/src/main/components/Utils/PageSizeSelector.jsx
+++ b/frontend/src/main/components/Utils/PageSizeSelector.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Form } from "react-bootstrap";
+
+export default function PageSizeSelector({
+  value,
+  onChange,
+  options = [20, 50, 100, 200, 500],
+  testid = "page-size-selector",
+}) {
+  const handleChange = (e) => {
+    onChange(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <Form.Group className="d-flex align-items-center gap-2 mt-2">
+      <Form.Label htmlFor="pageSize" className="mb-0">
+        Page Size
+      </Form.Label>
+      <Form.Select
+        id="pageSize"
+        data-testid={testid}
+        value={value}
+        onChange={handleChange}
+        // Stryker disable next-line all : this is for styling, which is unnecessary to test
+        style={{ width: "100px" }}
+      >
+        {options.map((option) => (
+          <option
+            key={option}
+            value={option}
+            data-testid={`${testid}-option-${option}`}
+          >
+            {option}
+          </option>
+        ))}
+      </Form.Select>
+    </Form.Group>
+  );
+}

--- a/frontend/src/tests/components/OurTable.test.jsx
+++ b/frontend/src/tests/components/OurTable.test.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   fireEvent,
   render,
@@ -471,5 +472,38 @@ describe("OurTable tests", () => {
     ).toContainHTML("4");
     expect(screen.queryByTestId("testid-forward-three-page-button")).toBe(null);
     expect(screen.queryByTestId("testid-back-three-page-button")).toBe(null);
+  });
+
+  test("changing pageSize while on a later page resets to the first page", async () => {
+    const Wrapper = () => {
+      const [pageSize, setPageSize] = React.useState(10);
+      return (
+        <>
+          <button data-testid="grow-page-size" onClick={() => setPageSize(50)}>
+            Grow page size
+          </button>
+          <OurTable columns={columns} data={elevenRows} pageSize={pageSize} />
+        </>
+      );
+    };
+
+    render(<Wrapper />);
+
+    const nextButton = await screen.findByTestId("testid-next-page-button");
+    fireEvent.click(nextButton);
+    expect(
+      await screen.findByTestId("testid-current-page-button"),
+    ).toContainHTML("2");
+    expect(await screen.findByText(`Hello 11`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("grow-page-size"));
+
+    // With pageSize now 50, all 11 rows fit on one page: pagination
+    // disappears rather than showing an empty page 2.
+    await waitFor(() => {
+      expect(screen.queryByTestId("testid-current-page-button")).toBe(null);
+    });
+    expect(await screen.findByText(`Hello 1`)).toBeInTheDocument();
+    expect(await screen.findByText(`Hello 11`)).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Students/StudentsTable.test.jsx
+++ b/frontend/src/tests/components/Students/StudentsTable.test.jsx
@@ -372,4 +372,52 @@ describe("StudentsTable tests", () => {
       expectedHeaders.length,
     );
   });
+
+  const manyStudents = Array.from({ length: 25 }, (_, i) => ({
+    id: i + 1,
+    lastName: `Last${i + 1}`,
+    firstMiddleName: `First${i + 1}`,
+    email: `student${i + 1}@ucsb.edu`,
+    perm: `100000${i}`,
+    courseId: 1,
+    lastLoginDateTime: null,
+  }));
+
+  test("renders a Page Size selector defaulting to 20", () => {
+    renderTable(manyStudents, currentUserFixtures.userOnly);
+
+    const selector = screen.getByTestId(`${testId}-page-size-selector`);
+    expect(selector).toBeInTheDocument();
+    expect(selector).toHaveValue("20");
+  });
+
+  test("with more students than the page size, pagination is shown and only a page's worth of rows render", () => {
+    renderTable(manyStudents, currentUserFixtures.userOnly);
+
+    expect(
+      screen.getByTestId(`${testId}-current-page-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-id`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-20-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("selecting a larger page size shows all rows and hides pagination", async () => {
+    renderTable(manyStudents, currentUserFixtures.userOnly);
+
+    const selector = screen.getByTestId(`${testId}-page-size-selector`);
+    fireEvent.change(selector, { target: { value: "50" } });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(`${testId}-current-page-button`),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-24-col-id`),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/components/Utils/PageSizeSelector.test.jsx
+++ b/frontend/src/tests/components/Utils/PageSizeSelector.test.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import PageSizeSelector from "main/components/Utils/PageSizeSelector";
+import { describe, expect, test, vi } from "vitest";
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [20, 50, 100, 200, 500];
+
+describe("PageSizeSelector component", () => {
+  test("renders with label 'Page Size'", () => {
+    render(<PageSizeSelector value={20} onChange={() => {}} />);
+    expect(screen.getByText("Page Size")).toBeInTheDocument();
+    expect(screen.getByTestId("page-size-selector")).toBeInTheDocument();
+  });
+
+  test("renders select with default testid", () => {
+    render(<PageSizeSelector value={20} onChange={() => {}} />);
+    expect(screen.getByTestId("page-size-selector")).toBeInTheDocument();
+  });
+
+  test("renders select with custom testid", () => {
+    render(
+      <PageSizeSelector
+        value={20}
+        onChange={() => {}}
+        testid="custom-testid"
+      />,
+    );
+    expect(screen.getByTestId("custom-testid")).toBeInTheDocument();
+  });
+
+  test("offers the expected default options: 20, 50, 100, 200, 500", () => {
+    render(<PageSizeSelector value={20} onChange={() => {}} />);
+    DEFAULT_PAGE_SIZE_OPTIONS.forEach((option) => {
+      expect(
+        screen.getByTestId(`page-size-selector-option-${option}`),
+      ).toHaveTextContent(String(option));
+    });
+  });
+
+  test("offers custom options when provided", () => {
+    render(
+      <PageSizeSelector value={5} onChange={() => {}} options={[5, 10, 15]} />,
+    );
+    [5, 10, 15].forEach((option) => {
+      expect(
+        screen.getByTestId(`page-size-selector-option-${option}`),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("page-size-selector-option-20"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("displays the current value", () => {
+    render(<PageSizeSelector value={100} onChange={() => {}} />);
+    const select = screen.getByTestId("page-size-selector");
+    expect(select).toHaveValue("100");
+  });
+
+  test("calls onChange with parsed integer when a new option is selected", () => {
+    const onChange = vi.fn();
+    render(<PageSizeSelector value={20} onChange={onChange} />);
+    const select = screen.getByTestId("page-size-selector");
+    fireEvent.change(select, { target: { value: "200" } });
+    expect(onChange).toHaveBeenCalledWith(200);
+  });
+
+  test("label is associated with select via htmlFor/id", () => {
+    render(<PageSizeSelector value={20} onChange={() => {}} />);
+    const label = screen.getByText("Page Size");
+    expect(label).toHaveAttribute("for", "pageSize");
+    const select = screen.getByTestId("page-size-selector");
+    expect(select).toHaveAttribute("id", "pageSize");
+  });
+});


### PR DESCRIPTION
## Summary
Closes #289.

The students table on a course's admin page (`/admin/courses/:courseNum`) paginated at a fixed size with no way for the admin to change it. Added a `PageSizeSelector` control above the table offering 20/50/100/200/500, wired to `OurTable`'s existing `pageSize` prop.

## Design notes
Per the issue, I looked at proj-courses, proj-dining, and proj-frontiers for existing patterns. proj-courses has an analogous `GenericDropdown` + `useLocalStorage` combo for its own page-size control - but that drives *server-side* pagination there, whereas this table paginates *client-side* via `OurTable` (the whole roster is fetched at once). This repo already has a very similar precedent for that situation: `BinSizeSelector` (used on `DashboardPage`) - a plain controlled `value`/`onChange` dropdown with no persistence. `PageSizeSelector` follows that same shape rather than porting the `useLocalStorage`-backed pattern, to stay consistent with this codebase's own existing convention and keep the change minimal. Happy to add persistence later if it turns out to be wanted.

## Bug found and fixed along the way
While building this, found that `OurTable` didn't reset its page index when the `pageSize` prop changed - if you were on page 3 of a table and then picked a bigger page size, it would silently render an empty table (or a wrong slice of rows) until you manually paged back. `OurTable` now resets to the first page whenever `pageSize` changes.

## Test plan
- [x] `PageSizeSelector` unit tests (default/custom options, testid, value display, onChange behavior, label association)
- [x] `OurTable` test covering the pageIndex-reset fix (go to page 2, grow the page size, confirm it lands back on all rows rather than an empty page)
- [x] `StudentsTable` tests: selector renders defaulting to 20, pagination shows/hides correctly as the page size changes
- [x] Full frontend `vitest` suite (764 tests, 100% coverage)
- [x] `lint` / `prettier --check` clean
- [x] Stryker mutation testing on all three changed files - 100% mutation score
- [x] No backend changes needed (this is client-side pagination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)