### PR TITLE
Add FarmerActivity tracking and admin activity-history page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
+import AdminFarmerActivityPage from "main/pages/AdminFarmerActivityPage";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
 import AdminEditAnnouncementsPage from "main/pages/AdminEditAnnouncementsPage";
@@ -53,6 +54,10 @@ function App() {
       <Route
         path="/admin/play/:gameId/user/:userId"
         element={<AdminViewPlayPage />}
+      />
+      <Route
+        path="/admin/farmeractivity/:gameId/user/:userId"
+        element={<AdminFarmerActivityPage />}
       />
       <Route
         path="/admin/announcements/:gameId"

--- a/frontend/src/main/components/Game/FarmerActivityTable.jsx
+++ b/frontend/src/main/components/Game/FarmerActivityTable.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import OurTable from "main/components/OurTable";
+import PageSizeSelector from "main/components/Utils/PageSizeSelector";
+import { useBackend } from "main/utils/useBackend";
+import { formatDateTime } from "main/utils/dateUtils";
+
+const ACTIVITY_TYPE_LABELS = {
+  0: "Viewed Play Page",
+  1: "Bought Cows",
+  2: "Sold Cows",
+};
+
+export default function FarmerActivityTable({
+  gameId,
+  userId,
+  testid = "FarmerActivityTable",
+}) {
+  const [pageSize, setPageSize] = useState(10);
+
+  // Stryker disable all
+  const { data: activity } = useBackend(
+    [`/api/farmeractivity/all?userId=${userId}&gameId=${gameId}`],
+    {
+      method: "GET",
+      url: "/api/farmeractivity/all",
+      params: {
+        userId: userId,
+        gameId: gameId,
+      },
+    },
+    [],
+  );
+  // Stryker restore all
+
+  const columns = [
+    {
+      Header: "Timestamp",
+      accessor: "timestamp",
+      Cell: ({ value }) => formatDateTime(value),
+    },
+    {
+      Header: "Activity",
+      accessor: "activityType",
+      Cell: ({ value }) => ACTIVITY_TYPE_LABELS[value] ?? value,
+    },
+    {
+      Header: "Cows",
+      accessor: "numCows",
+    },
+  ];
+
+  return (
+    <>
+      <PageSizeSelector
+        value={pageSize}
+        onChange={setPageSize}
+        options={[10, 50, 100]}
+        testid={`${testid}-page-size-selector`}
+      />
+      <OurTable
+        data={activity}
+        columns={columns}
+        testid={testid}
+        centered={false}
+        pageSize={pageSize}
+      />
+    </>
+  );
+}

--- a/frontend/src/main/components/Game/FarmerActivityTable.jsx
+++ b/frontend/src/main/components/Game/FarmerActivityTable.jsx
@@ -2,13 +2,30 @@ import React, { useState } from "react";
 import OurTable from "main/components/OurTable";
 import PageSizeSelector from "main/components/Utils/PageSizeSelector";
 import { useBackend } from "main/utils/useBackend";
-import { formatDateTime } from "main/utils/dateUtils";
 
 const ACTIVITY_TYPE_LABELS = {
   0: "Viewed Play Page",
   1: "Bought Cows",
   2: "Sold Cows",
 };
+
+// The backend stores/serializes this as a naive "YYYY-MM-DDTHH:mm:ss"
+// LocalDateTime that's already in Pacific time (see FarmerActivityService).
+// Format its digits directly rather than going through `new Date(...)`: a
+// date-time string with no timezone offset is parsed by JS using the
+// *viewing browser's* local timezone, which would silently show the wrong
+// time for anyone not physically in the Pacific timezone. See issue #291.
+function formatPacificTimestamp(dateTimeString) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(dateTimeString);
+  if (!match) {
+    return "";
+  }
+  const [, year, month, day, hour24Str, minute] = match;
+  const hour24 = Number(hour24Str);
+  const period = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = ((hour24 + 11) % 12) + 1;
+  return `${month}/${day}/${year}, ${hour12}:${minute} ${period}`;
+}
 
 export default function FarmerActivityTable({
   gameId,
@@ -36,7 +53,7 @@ export default function FarmerActivityTable({
     {
       Header: "Timestamp",
       accessor: "timestamp",
-      Cell: ({ value }) => formatDateTime(value),
+      Cell: ({ value }) => formatPacificTimestamp(value),
     },
     {
       Header: "Activity",

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
@@ -19,6 +19,27 @@ export default function LeaderboardTable({ leaderboardUsers, isAdminView }) {
         return <Link to={url}>{row.username}</Link>;
       },
     },
+    ...(isAdminView
+      ? [
+          {
+            Header: "Activity",
+            accessor: (row, _rowIndex) => {
+              const url = `/admin/farmeractivity/${row.gameId}/user/${row.userId}`;
+              return (
+                <Button
+                  as={Link}
+                  to={url}
+                  variant="outline-secondary"
+                  size="sm"
+                  data-testid={`LeaderboardTable-cell-row-${_rowIndex}-col-Activity-button`}
+                >
+                  Activity
+                </Button>
+              );
+            },
+          },
+        ]
+      : []),
     {
       Header: "Total Wealth",
       accessor: "totalWealth",
@@ -69,27 +90,6 @@ export default function LeaderboardTable({ leaderboardUsers, isAdminView }) {
         return <div style={{ textAlign: "right" }}>{props.value}</div>;
       },
     },
-    ...(isAdminView
-      ? [
-          {
-            Header: "Activity",
-            accessor: (row, _rowIndex) => {
-              const url = `/admin/farmeractivity/${row.gameId}/user/${row.userId}`;
-              return (
-                <Button
-                  as={Link}
-                  to={url}
-                  variant="outline-secondary"
-                  size="sm"
-                  data-testid={`LeaderboardTable-cell-row-${_rowIndex}-col-Activity-button`}
-                >
-                  Activity
-                </Button>
-              );
-            },
-          },
-        ]
-      : []),
   ];
 
   const testid = "LeaderboardTable";

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
@@ -4,8 +4,16 @@ import { Button } from "react-bootstrap";
 
 // should take in a players list from a game. isAdminView (true only for an
 // admin NOT viewing the leaderboard in "Student View" - see DashboardPage)
-// controls whether the admin-only Activity column is shown, per issue #291.
-export default function LeaderboardTable({ leaderboardUsers, isAdminView }) {
+// and isCourseLinkedGame (activity is never tracked for a game with no
+// course) together control whether the admin-only Activity column is shown
+// at all; within that column, a farmer who isn't a student on the course's
+// roster (row.student === false) gets "Not a student" instead of a button,
+// since no activity is tracked for them either. See issue #291.
+export default function LeaderboardTable({
+  leaderboardUsers,
+  isAdminView,
+  isCourseLinkedGame,
+}) {
   const USD = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
@@ -19,11 +27,20 @@ export default function LeaderboardTable({ leaderboardUsers, isAdminView }) {
         return <Link to={url}>{row.username}</Link>;
       },
     },
-    ...(isAdminView
+    ...(isAdminView && isCourseLinkedGame
       ? [
           {
             Header: "Activity",
             accessor: (row, _rowIndex) => {
+              if (!row.student) {
+                return (
+                  <span
+                    data-testid={`LeaderboardTable-cell-row-${_rowIndex}-col-Activity-not-a-student`}
+                  >
+                    Not a student
+                  </span>
+                );
+              }
               const url = `/admin/farmeractivity/${row.gameId}/user/${row.userId}`;
               return (
                 <Button

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.jsx
@@ -1,8 +1,11 @@
 import OurTable from "main/components/OurTable";
 import { Link } from "react-router";
+import { Button } from "react-bootstrap";
 
-// should take in a players list from a game
-export default function LeaderboardTable({ leaderboardUsers }) {
+// should take in a players list from a game. isAdminView (true only for an
+// admin NOT viewing the leaderboard in "Student View" - see DashboardPage)
+// controls whether the admin-only Activity column is shown, per issue #291.
+export default function LeaderboardTable({ leaderboardUsers, isAdminView }) {
   const USD = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
@@ -66,6 +69,27 @@ export default function LeaderboardTable({ leaderboardUsers }) {
         return <div style={{ textAlign: "right" }}>{props.value}</div>;
       },
     },
+    ...(isAdminView
+      ? [
+          {
+            Header: "Activity",
+            accessor: (row, _rowIndex) => {
+              const url = `/admin/farmeractivity/${row.gameId}/user/${row.userId}`;
+              return (
+                <Button
+                  as={Link}
+                  to={url}
+                  variant="outline-secondary"
+                  size="sm"
+                  data-testid={`LeaderboardTable-cell-row-${_rowIndex}-col-Activity-button`}
+                >
+                  Activity
+                </Button>
+              );
+            },
+          },
+        ]
+      : []),
   ];
 
   const testid = "LeaderboardTable";

--- a/frontend/src/main/pages/AdminFarmerActivityPage.jsx
+++ b/frontend/src/main/pages/AdminFarmerActivityPage.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useParams } from "react-router";
+import { Container } from "react-bootstrap";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import FarmerActivityTable from "main/components/Game/FarmerActivityTable";
+import { useBackend } from "main/utils/useBackend";
+
+export default function AdminFarmerActivityPage() {
+  const { gameId, userId } = useParams();
+
+  // Stryker disable all
+  const { data: farmer } = useBackend("/api/farmer", {
+    method: "GET",
+    url: "/api/farmer",
+    params: {
+      userId: userId,
+      gameId: gameId,
+    },
+  });
+
+  const { data: gamePlus } = useBackend([`/api/game/plus?id=${gameId}`], {
+    method: "GET",
+    url: "/api/game/plus",
+    params: {
+      id: gameId,
+    },
+  });
+  // Stryker restore all
+
+  return (
+    <BasicLayout>
+      <Container className="pt-2">
+        <h1 data-testid="AdminFarmerActivityPage-title">
+          Activity for <strong>{farmer?.username}</strong> in{" "}
+          <strong>{gamePlus?.game?.name}</strong>
+        </h1>
+        <FarmerActivityTable
+          gameId={gameId}
+          userId={userId}
+          testid="AdminFarmerActivityPage-table"
+        />
+      </Container>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/DashboardPage.jsx
+++ b/frontend/src/main/pages/DashboardPage.jsx
@@ -418,6 +418,7 @@ export default function DashboardPage() {
             <LeaderboardTable
               leaderboardUsers={farmer}
               currentUser={currentUser}
+              isAdminView={isAdminView}
             />
           </DashboardSectionCard>
         </>

--- a/frontend/src/main/pages/DashboardPage.jsx
+++ b/frontend/src/main/pages/DashboardPage.jsx
@@ -48,6 +48,11 @@ export default function DashboardPage() {
   // its normal (non-"View as Student") mode.
   const isAdminView = isAdmin && !viewAsStudent;
 
+  // Activity is never tracked for games that aren't linked to a course (see
+  // issue #291), so the leaderboard's Activity column doesn't make sense
+  // there either.
+  const isCourseLinkedGame = game?.courseId != null;
+
   const showDashboardToStudents = game?.showLeaderboard === true;
   const showOverviewSection = game?.showOverviewSection !== false;
   const showCowsPerFarmerSection = game?.showCowsPerFarmerSection !== false;
@@ -419,6 +424,7 @@ export default function DashboardPage() {
               leaderboardUsers={farmer}
               currentUser={currentUser}
               isAdminView={isAdminView}
+              isCourseLinkedGame={isCourseLinkedGame}
             />
           </DashboardSectionCard>
         </>

--- a/frontend/src/main/pages/PlayPage.jsx
+++ b/frontend/src/main/pages/PlayPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Container, CardGroup, Button } from "react-bootstrap";
 import { useParams } from "react-router";
 
@@ -64,6 +64,32 @@ export default function PlayPage() {
       },
     },
   );
+  // Stryker restore all
+
+  // Records a play-page-view activity row (see issue #291). The backend
+  // silently no-ops unless this game is linked to a course and the current
+  // user's email matches a student on that course's roster, so it's safe to
+  // fire on every navigation here without checking eligibility client-side.
+  // Only PlayPage does this - AdminViewPlayPage (an admin emulating a
+  // farmer's view) must not count as a visit.
+  // Stryker disable all: a background tracking call with no observable UI
+  // outcome to assert on.
+  const objectToAxiosParamsPageView = () => ({
+    url: "/api/farmeractivity/pageview",
+    method: "POST",
+    params: {
+      gameId: gameId,
+    },
+  });
+
+  const mutationPageView = useBackendMutation(objectToAxiosParamsPageView);
+
+  useEffect(() => {
+    if (gameId) {
+      mutationPageView.mutate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameId]);
   // Stryker restore all
 
   const gamePlusExists = !(typeof gamePlus == "undefined");

--- a/frontend/src/tests/components/Game/FarmerActivityTable.test.jsx
+++ b/frontend/src/tests/components/Game/FarmerActivityTable.test.jsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import FarmerActivityTable from "main/components/Game/FarmerActivityTable";
+
+describe("FarmerActivityTable tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "FarmerActivityTable";
+
+  const activity = [
+    {
+      id: 3,
+      studentId: 42,
+      timestamp: "2024-01-15T10:20:00",
+      activityType: 1,
+      numCows: 3,
+    },
+    {
+      id: 2,
+      studentId: 42,
+      timestamp: "2024-01-15T10:15:00",
+      activityType: 2,
+      numCows: 1,
+    },
+    {
+      id: 1,
+      studentId: 42,
+      timestamp: "2024-01-15T10:00:00",
+      activityType: 0,
+      numCows: 0,
+    },
+  ];
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+  const renderTable = (props = {}) => {
+    return render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <FarmerActivityTable gameId={1} userId={2} {...props} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  test("renders the table flush left, not centered", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, activity);
+
+    const { container } = renderTable();
+
+    await waitFor(() => {
+      expect(container.querySelector("table")).toBeInTheDocument();
+    });
+    expect(container.querySelector("table")).toHaveStyle({ margin: "0" });
+  });
+
+  test("fetches from the admin endpoint with gameId/userId and renders rows", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, activity);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-activityType`),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-activityType`),
+    ).toHaveTextContent("Bought Cows");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-activityType`),
+    ).toHaveTextContent("Sold Cows");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-activityType`),
+    ).toHaveTextContent("Viewed Play Page");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-numCows`),
+    ).toHaveTextContent("3");
+
+    expect(axiosMock.history.get[0].params).toEqual({ userId: 2, gameId: 1 });
+  });
+
+  test("formats the timestamp column", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [activity[0]]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+      ).toBeInTheDocument();
+    });
+
+    // formatDateTime renders e.g. "01/15/2024, 10:20 AM" - just assert it's
+    // not the raw ISO string, and contains the date.
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+    ).toHaveTextContent("01/15/2024");
+  });
+
+  test("falls back to the raw activityType value for an unrecognized type", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [{ ...activity[0], activityType: 99 }]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-activityType`),
+      ).toHaveTextContent("99");
+    });
+  });
+
+  test("renders headers even when there is no activity", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, []);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getByText("Timestamp")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("Cows")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-activityType`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("PageSizeSelector controls the table's page size, defaulting to 10", async () => {
+    const manyRows = Array.from({ length: 15 }, (_, i) => ({
+      id: i + 1,
+      studentId: 42,
+      timestamp: "2024-01-15T10:00:00",
+      activityType: 0,
+      numCows: 0,
+    }));
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, manyRows);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-9-col-activityType`),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-10-col-activityType`),
+    ).not.toBeInTheDocument();
+
+    const pageSizeSelector = screen.getByTestId(`${testId}-page-size-selector`);
+    fireEvent.change(pageSizeSelector, { target: { value: "50" } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-14-col-activityType`),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/Game/FarmerActivityTable.test.jsx
+++ b/frontend/src/tests/components/Game/FarmerActivityTable.test.jsx
@@ -92,7 +92,7 @@ describe("FarmerActivityTable tests", () => {
     expect(axiosMock.history.get[0].params).toEqual({ userId: 2, gameId: 1 });
   });
 
-  test("formats the timestamp column", async () => {
+  test("formats the timestamp column from its own digits, in AM", async () => {
     axiosMock
       .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
       .reply(200, [activity[0]]);
@@ -105,11 +105,83 @@ describe("FarmerActivityTable tests", () => {
       ).toBeInTheDocument();
     });
 
-    // formatDateTime renders e.g. "01/15/2024, 10:20 AM" - just assert it's
-    // not the raw ISO string, and contains the date.
+    // activity[0].timestamp is "2024-01-15T10:20:00" - a naive Pacific
+    // LocalDateTime string with no timezone offset. This must be formatted
+    // from its own digits, not via `new Date(...)`, which would otherwise
+    // reinterpret it using the *test runner's* local timezone rather than
+    // Pacific (see issue #291) - so this assertion would fail if the
+    // component ever regressed to doing that in a non-Pacific CI runner.
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
-    ).toHaveTextContent("01/15/2024");
+    ).toHaveTextContent("01/15/2024, 10:20 AM");
+  });
+
+  test("formats an afternoon (PM) timestamp correctly", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [{ ...activity[0], timestamp: "2024-01-15T14:05:00" }]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+      ).toHaveTextContent("01/15/2024, 2:05 PM");
+    });
+  });
+
+  test("formats midnight and noon correctly (12-hour edge cases)", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [
+        { ...activity[0], id: 1, timestamp: "2024-01-15T00:00:00" },
+        { ...activity[0], id: 2, timestamp: "2024-01-15T12:00:00" },
+      ]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+      ).toHaveTextContent("01/15/2024, 12:00 AM");
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-timestamp`),
+    ).toHaveTextContent("01/15/2024, 12:00 PM");
+  });
+
+  test("renders an empty timestamp cell for a null value", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [{ ...activity[0], timestamp: null }]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-activityType`),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+    ).toHaveTextContent("");
+  });
+
+  test("renders an empty timestamp cell for a non-null value that doesn't match the expected format", async () => {
+    axiosMock
+      .onGet("/api/farmeractivity/all", { params: { userId: 2, gameId: 1 } })
+      .reply(200, [{ ...activity[0], timestamp: "not-a-date" }]);
+
+    renderTable();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-activityType`),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-timestamp`),
+    ).toHaveTextContent("");
   });
 
   test("falls back to the raw activityType value for an unrecognized type", async () => {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.jsx
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.jsx
@@ -245,6 +245,7 @@ describe("LeaderboardTable tests", () => {
           <LeaderboardTable
             leaderboardUsers={leaderboardFixtures.fiveFarmerLB}
             isAdminView={false}
+            isCourseLinkedGame={true}
           />
         </MemoryRouter>
       </QueryClientProvider>,
@@ -253,13 +254,34 @@ describe("LeaderboardTable tests", () => {
     expect(screen.queryByText("Activity")).not.toBeInTheDocument();
   });
 
-  test("Activity column is shown and links to the correct URL when isAdminView is true", () => {
+  test("Activity column is hidden when isCourseLinkedGame is false, even for an admin", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <LeaderboardTable
             leaderboardUsers={leaderboardFixtures.fiveFarmerLB}
             isAdminView={true}
+            isCourseLinkedGame={false}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Activity")).not.toBeInTheDocument();
+  });
+
+  test("Activity column shows a button linking to the correct URL for a student farmer", () => {
+    const leaderboardUsers = [
+      { ...leaderboardFixtures.fiveFarmerLB[0], student: true },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable
+            leaderboardUsers={leaderboardUsers}
+            isAdminView={true}
+            isCourseLinkedGame={true}
           />
         </MemoryRouter>
       </QueryClientProvider>,
@@ -276,5 +298,32 @@ describe("LeaderboardTable tests", () => {
       "href",
       "/admin/farmeractivity/1/user/1",
     );
+  });
+
+  test('Activity column shows "Not a student" for a non-student farmer', () => {
+    const leaderboardUsers = [
+      { ...leaderboardFixtures.fiveFarmerLB[0], student: false },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable
+            leaderboardUsers={leaderboardUsers}
+            isAdminView={true}
+            isCourseLinkedGame={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByTestId(
+        "LeaderboardTable-cell-row-0-col-Activity-not-a-student",
+      ),
+    ).toHaveTextContent("Not a student");
+    expect(
+      screen.queryByTestId("LeaderboardTable-cell-row-0-col-Activity-button"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.jsx
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.jsx
@@ -237,4 +237,44 @@ describe("LeaderboardTable tests", () => {
 
     fireEvent.click(link);
   });
+
+  test("Activity column is hidden when isAdminView is false", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable
+            leaderboardUsers={leaderboardFixtures.fiveFarmerLB}
+            isAdminView={false}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Activity")).not.toBeInTheDocument();
+  });
+
+  test("Activity column is shown and links to the correct URL when isAdminView is true", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable
+            leaderboardUsers={leaderboardFixtures.fiveFarmerLB}
+            isAdminView={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByTestId("LeaderboardTable-header-Activity"),
+    ).toHaveTextContent("Activity");
+
+    const activityLink = screen.getByTestId(
+      "LeaderboardTable-cell-row-0-col-Activity-button",
+    );
+    expect(activityLink).toHaveAttribute(
+      "href",
+      "/admin/farmeractivity/1/user/1",
+    );
+  });
 });

--- a/frontend/src/tests/pages/AdminFarmerActivityPage.test.jsx
+++ b/frontend/src/tests/pages/AdminFarmerActivityPage.test.jsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { vi } from "vitest";
+
+import AdminFarmerActivityPage from "main/pages/AdminFarmerActivityPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+vi.mock("react-router", async () => ({
+  ...(await vi.importActual("react-router")),
+  useParams: () => ({
+    gameId: "1",
+    userId: "2",
+  }),
+}));
+
+describe("AdminFarmerActivityPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+
+    axiosMock
+      .onGet("/api/farmer", { params: { userId: "2", gameId: "1" } })
+      .reply(200, { userId: 2, gameId: 1, username: "farmerjoe" });
+
+    axiosMock
+      .onGet("/api/game/plus", { params: { id: "1" } })
+      .reply(200, { game: { id: 1, name: "Sample Game" }, totalPlayers: 5 });
+
+    axiosMock
+      .onGet("/api/farmeractivity/all", {
+        params: { userId: "2", gameId: "1" },
+      })
+      .reply(200, []);
+  });
+
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminFarmerActivityPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("AdminFarmerActivityPage-title"),
+    ).toBeInTheDocument();
+  });
+
+  test("shows the farmer's username and game name in the title", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminFarmerActivityPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("AdminFarmerActivityPage-title"),
+      ).toHaveTextContent("Activity for farmerjoe in Sample Game");
+    });
+  });
+
+  test("renders the FarmerActivityTable with the right gameId/userId", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminFarmerActivityPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("AdminFarmerActivityPage-table-page-size-selector"),
+      ).toBeInTheDocument();
+    });
+
+    const activityCall = axiosMock.history.get.find(
+      (call) => call.url === "/api/farmeractivity/all",
+    );
+    expect(activityCall.params).toEqual({ userId: "2", gameId: "1" });
+  });
+
+  test("does not crash when gamePlus has no game (e.g. before it loads)", async () => {
+    axiosMock
+      .onGet("/api/game/plus", { params: { id: "1" } })
+      .reply(200, { totalPlayers: 5 });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminFarmerActivityPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("AdminFarmerActivityPage-title"),
+    ).toHaveTextContent("Activity for farmerjoe in");
+  });
+});

--- a/frontend/src/tests/pages/DashboardPage.test.jsx
+++ b/frontend/src/tests/pages/DashboardPage.test.jsx
@@ -157,6 +157,44 @@ describe("DashboardPage as admin", () => {
     expect(within(stdDevCard).getByText("1.5")).toBeInTheDocument();
   });
 
+  test("hides the leaderboard's Activity column when the game is not linked to a course", async () => {
+    // baseGamePlus.game has no courseId
+    renderWithRoute("/dashboard/7");
+
+    await screen.findByRole("heading", { name: /test game 7/i });
+
+    expect(
+      screen.queryByTestId("LeaderboardTable-header-Activity"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows the leaderboard's Activity column when the game is linked to a course", async () => {
+    axiosMock.onGet("/api/game/plus").reply(200, {
+      ...baseGamePlus,
+      game: { ...baseGamePlus.game, courseId: 5 },
+    });
+    axiosMock.onGet("/api/farmer/game/all").reply(200, [
+      {
+        userId: 1,
+        gameId: 7,
+        username: "student1",
+        totalWealth: 100,
+        numOfCows: 1,
+        cowHealth: 100,
+        cowsBought: 1,
+        cowsSold: 0,
+        cowDeaths: 0,
+        student: true,
+      },
+    ]);
+
+    renderWithRoute("/dashboard/7");
+
+    expect(
+      await screen.findByTestId("LeaderboardTable-header-Activity"),
+    ).toBeInTheDocument();
+  });
+
   test("shows a loading message before the game data has loaded", async () => {
     let resolvePlus;
     const plusPromise = new Promise((resolve) => {

--- a/frontend/src/tests/pages/PlayPage.test.jsx
+++ b/frontend/src/tests/pages/PlayPage.test.jsx
@@ -100,6 +100,8 @@ describe("PlayPage tests", () => {
 
     axiosMock.onPut("/api/farmer/sell").reply(200, farmerResponse.body);
     axiosMock.onPut("/api/farmer/buy").reply(200, farmerResponse.body);
+
+    axiosMock.onPost("/api/farmeractivity/pageview").reply(200);
   };
 
   const renderPage = () => {
@@ -141,6 +143,29 @@ describe("PlayPage tests", () => {
         "This game has been hidden by the site administrator.",
       ),
     ).not.toBeInTheDocument();
+  });
+
+  test("records a page-view activity for this game on navigation", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        axiosMock.history.post.some(
+          (call) => call.url === "/api/farmeractivity/pageview",
+        ),
+      ).toBe(true);
+    });
+
+    const pageViewCall = axiosMock.history.post.find(
+      (call) => call.url === "/api/farmeractivity/pageview",
+    );
+    expect(pageViewCall.params).toEqual({ gameId: 1 });
+
+    // Fires exactly once for this navigation, not once per render.
+    const pageViewCalls = axiosMock.history.post.filter(
+      (call) => call.url === "/api/farmeractivity/pageview",
+    );
+    expect(pageViewCalls.length).toBe(1);
   });
 
   test("cannot join hidden game", async () => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityController.java
@@ -1,0 +1,76 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.happiercows.entities.Farmer;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Game;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.repositories.FarmerActivityRepository;
+import edu.ucsb.cs156.happiercows.repositories.FarmerRepository;
+import edu.ucsb.cs156.happiercows.repositories.GameRepository;
+import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Farmer Activity")
+@RequestMapping("/api/farmeractivity")
+@RestController
+public class FarmerActivityController extends ApiController {
+
+  @Autowired
+  private FarmerActivityRepository farmerActivityRepository;
+
+  @Autowired
+  private FarmerRepository farmerRepository;
+
+  @Autowired
+  private GameRepository gameRepository;
+
+  @Autowired
+  private FarmerActivityService farmerActivityService;
+
+  @Operation(
+      summary =
+          "Record a play-page view for the current user, if their email matches a student "
+              + "on the roster of the course this game is linked to (a no-op otherwise)")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PostMapping("/pageview")
+  public void recordPageView(@Parameter(name = "gameId") @RequestParam Long gameId) {
+
+    User user = getCurrentUser().getUser();
+
+    Game game = gameRepository.findById(gameId)
+        .orElseThrow(() -> new EntityNotFoundException("Game", gameId));
+
+    Optional<Farmer> farmer = farmerRepository.findByGameIdAndUserId(gameId, user.getId());
+    farmer.ifPresent(f -> farmerActivityService.recordActivityIfStudentMatch(
+        user, game, f, FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW, 0));
+  }
+
+  @Operation(summary = "Get a farmer's activity history (admin only), reverse chronological")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/all")
+  public List<FarmerActivity> getActivityForFarmer(
+      @Parameter(name = "userId") @RequestParam Long userId,
+      @Parameter(name = "gameId") @RequestParam Long gameId) {
+
+    Farmer farmer = farmerRepository.findByGameIdAndUserId(gameId, userId)
+        .orElseThrow(
+            () -> new EntityNotFoundException(Farmer.class, "gameId", gameId, "userId", userId));
+
+    return farmerActivityRepository.findByFarmerOrderByTimestampDesc(farmer);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityController.java
@@ -57,7 +57,7 @@ public class FarmerActivityController extends ApiController {
 
     Optional<Farmer> farmer = farmerRepository.findByGameIdAndUserId(gameId, user.getId());
     farmer.ifPresent(f -> farmerActivityService.recordActivityIfStudentMatch(
-        user, game, f, FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW, 0));
+        user, game, f, FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW, f.getNumOfCows()));
   }
 
   @Operation(summary = "Get a farmer's activity history (admin only), reverse chronological")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerController.java
@@ -15,6 +15,7 @@ import edu.ucsb.cs156.happiercows.repositories.FarmerRepository;
 import edu.ucsb.cs156.happiercows.repositories.GameRepository;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.Farmer;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
 import edu.ucsb.cs156.happiercows.entities.Game;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.errors.NoCowsException;
@@ -22,6 +23,7 @@ import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
 import edu.ucsb.cs156.happiercows.errors.GameHiddenException;
 import edu.ucsb.cs156.happiercows.errors.NotEnrolledInCourseAssociatedWithGameException;
 import edu.ucsb.cs156.happiercows.services.CourseAccessService;
+import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,6 +48,9 @@ public class FarmerController extends ApiController {
 
   @Autowired
   private CourseAccessService courseAccessService;
+
+  @Autowired
+  private FarmerActivityService farmerActivityService;
 
   @Operation(summary = "Get a specific user game (admin only)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -110,6 +115,9 @@ public class FarmerController extends ApiController {
         }
         farmerRepository.save(farmer);
 
+        farmerActivityService.recordActivityIfStudentMatch(
+            u, game, farmer, FarmerActivity.ACTIVITY_TYPE_BUY, numCows);
+
         String body = mapper.writeValueAsString(farmer);
         return ResponseEntity.ok().body(body);
     }
@@ -147,6 +155,9 @@ public class FarmerController extends ApiController {
           throw new NoCowsException("You do not have enough cows to sell!");
         }
         farmerRepository.save(farmer);
+
+        farmerActivityService.recordActivityIfStudentMatch(
+            u, game, farmer, FarmerActivity.ACTIVITY_TYPE_SELL, numCows);
 
         String body = mapper.writeValueAsString(farmer);
         return ResponseEntity.ok().body(body);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FarmerController.java
@@ -22,8 +22,12 @@ import edu.ucsb.cs156.happiercows.errors.NoCowsException;
 import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
 import edu.ucsb.cs156.happiercows.errors.GameHiddenException;
 import edu.ucsb.cs156.happiercows.errors.NotEnrolledInCourseAssociatedWithGameException;
+import edu.ucsb.cs156.happiercows.models.FarmerWithStudentStatus;
 import edu.ucsb.cs156.happiercows.services.CourseAccessService;
 import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -168,13 +172,32 @@ public class FarmerController extends ApiController {
     @Operation(summary = "Get all user game for a specific game")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/game/all")
-    public  ResponseEntity<String> getFarmersByGameId(
-        @Parameter(name="gameId") @RequestParam Long gameId) throws JsonProcessingException {
-      Iterable<Farmer> uc = farmerRepository.findByGameId(gameId);
-      
-   
-    String body = mapper.writeValueAsString(uc);
-    return ResponseEntity.ok().body(body);
+    public List<FarmerWithStudentStatus> getFarmersByGameId(
+        @Parameter(name="gameId") @RequestParam Long gameId) {
+
+      Game game = gameRepository.findById(gameId)
+          .orElseThrow(() -> new EntityNotFoundException("Game", gameId));
+
+      List<FarmerWithStudentStatus> result = new ArrayList<>();
+      for (Farmer farmer : farmerRepository.findByGameId(gameId)) {
+        boolean isStudent = courseAccessService
+            .findMatchingStudentForCourseLinkedGame(farmer.getUser(), game)
+            .isPresent();
+
+        result.add(FarmerWithStudentStatus.builder()
+            .userId(farmer.getUserId())
+            .gameId(farmer.getGameId())
+            .username(farmer.getUsername())
+            .totalWealth(farmer.getTotalWealth())
+            .numOfCows(farmer.getNumOfCows())
+            .cowHealth(farmer.getCowHealth())
+            .cowsBought(farmer.getCowsBought())
+            .cowsSold(farmer.getCowsSold())
+            .cowDeaths(farmer.getCowDeaths())
+            .student(isStudent)
+            .build());
+      }
+      return result;
   }
 
   private void ensureUserCanAccessCourseLinkedGame(User user, Game game) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/FarmerActivity.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/FarmerActivity.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "farmer_activity")
+
+public class FarmerActivity {
+
+    public static final int ACTIVITY_TYPE_PLAY_PAGE_VIEW = 0;
+    public static final int ACTIVITY_TYPE_BUY = 1;
+    public static final int ACTIVITY_TYPE_SELL = 2;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    // See Profit.farmer for why this is a @ManyToOne over Farmer's composite
+    // (user_id, game_id) key rather than a single farmerId column: Farmer
+    // has no single-column primary key to reference.
+    @ManyToOne
+    @JoinColumns({
+        @JoinColumn(name = "user_id", referencedColumnName = "user_id"),
+        @JoinColumn(name = "game_id", referencedColumnName = "game_id")
+    })
+    private Farmer farmer;
+
+    private Long studentId;
+    private LocalDateTime timestamp;
+    private int activityType;
+    private int numCows;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/FarmerWithStudentStatus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/FarmerWithStudentStatus.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import lombok.*;
+
+// A Farmer's leaderboard row, plus whether they're a student on the roster
+// of the course their game is linked to (see issue #291: the leaderboard's
+// admin-only Activity column only makes sense for farmers whose activity is
+// actually tracked, i.e. course-linked games and farmers who are students
+// on that course's roster).
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FarmerWithStudentStatus {
+    private long userId;
+    private long gameId;
+    private String username;
+    private double totalWealth;
+    private int numOfCows;
+    private double cowHealth;
+    private int cowsBought;
+    private int cowsSold;
+    private int cowDeaths;
+    private boolean student;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/FarmerActivityRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/FarmerActivityRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import java.util.List;
+
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Farmer;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FarmerActivityRepository extends CrudRepository<FarmerActivity, Long> {
+    List<FarmerActivity> findByFarmerOrderByTimestampDesc(Farmer farmer);
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CourseAccessService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CourseAccessService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Determines whether a user has access to a course-linked Game, based on
@@ -75,5 +76,30 @@ public class CourseAccessService {
         }
 
         return courseIds;
+    }
+
+    /**
+     * Returns the Student roster row that corresponds to this user, for the
+     * course linked to the given game - but only if the game is actually
+     * linked to a course. Used to decide whether a FarmerActivity row should
+     * be recorded for a play-page view or a buy/sell action: activity is
+     * only tracked for course-linked games, and only for users whose email
+     * matches a student on that course's roster (see issue #291), using the
+     * same canonical-email-matching rule as {@link #getCourseIdsForUser}.
+     */
+    public Optional<Student> findMatchingStudentForCourseLinkedGame(User user, Game game) {
+        if (game.getCourseId() == null) {
+            return Optional.empty();
+        }
+
+        String email = user.getEmail();
+
+        for (Student student : studentRepository.findByCourseId(game.getCourseId())) {
+            if (CanonicalFormConverter.areEquivalentEmails(student.getEmail(), email)) {
+                return Optional.of(student);
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/FarmerActivityService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/FarmerActivityService.java
@@ -1,0 +1,56 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.Farmer;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Game;
+import edu.ucsb.cs156.happiercows.entities.Student;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.repositories.FarmerActivityRepository;
+
+/**
+ * Records FarmerActivity rows (play-page views, buy/sell actions) for
+ * course-linked games whose farmer's email matches a student on that
+ * course's roster. See issue #291.
+ */
+@Service
+public class FarmerActivityService {
+
+    @Autowired
+    private CourseAccessService courseAccessService;
+
+    @Autowired
+    private FarmerActivityRepository farmerActivityRepository;
+
+    /**
+     * Records a FarmerActivity row for the given user/game/farmer/activityType,
+     * but only if the game is linked to a course and the user's email matches
+     * a student on that course's roster. Silently does nothing otherwise:
+     * tracking is opt-in-by-roster-membership, not an error condition when
+     * it doesn't apply (e.g. a standalone game with no course, or a course
+     * staff member rather than a student).
+     */
+    public void recordActivityIfStudentMatch(
+            User user, Game game, Farmer farmer, int activityType, int numCows) {
+        Optional<Student> matchingStudent =
+                courseAccessService.findMatchingStudentForCourseLinkedGame(user, game);
+        if (matchingStudent.isEmpty()) {
+            return;
+        }
+
+        FarmerActivity activity = FarmerActivity.builder()
+                .farmer(farmer)
+                .studentId(matchingStudent.get().getId())
+                .timestamp(LocalDateTime.now())
+                .activityType(activityType)
+                .numCows(numCows)
+                .build();
+
+        farmerActivityRepository.save(activity);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/FarmerActivityService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/FarmerActivityService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.happiercows.services;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,13 @@ import edu.ucsb.cs156.happiercows.repositories.FarmerActivityRepository;
  */
 @Service
 public class FarmerActivityService {
+
+    // The server's JVM default timezone isn't guaranteed to be Pacific (it's
+    // commonly UTC in a deployed container), and FarmerActivity.timestamp is
+    // a LocalDateTime with no zone of its own, so the wall-clock value has
+    // to be computed in the right zone explicitly - matching the convention
+    // already used for announcements/CSV exports elsewhere in this app.
+    private static final ZoneId LOCAL_TIME_ZONE = ZoneId.of("America/Los_Angeles");
 
     @Autowired
     private CourseAccessService courseAccessService;
@@ -46,7 +54,7 @@ public class FarmerActivityService {
         FarmerActivity activity = FarmerActivity.builder()
                 .farmer(farmer)
                 .studentId(matchingStudent.get().getId())
-                .timestamp(LocalDateTime.now())
+                .timestamp(LocalDateTime.now(LOCAL_TIME_ZONE))
                 .activityType(activityType)
                 .numCows(numCows)
                 .build();

--- a/src/main/resources/db/migration/changes/009_create_farmer_activity_table.json
+++ b/src/main/resources/db/migration/changes/009_create_farmer_activity_table.json
@@ -1,0 +1,107 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "009-create-farmer-activity-table",
+        "author": "pc",
+        "comment": "Create the farmer_activity table (see issue #291): tracks play-page views and buy/sell actions for farmers whose game is linked to a course and whose email matches a student on that course's roster.",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "farmer_activity"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "farmer_activity",
+              "columns": [
+                {
+                  "column": {
+                    "name": "id",
+                    "type": "BIGINT",
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "FARMER_ACTIVITY_PK"
+                    }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "user_id",
+                    "type": "BIGINT",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "game_id",
+                    "type": "BIGINT",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "student_id",
+                    "type": "BIGINT",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "timestamp",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "activity_type",
+                    "type": "INT",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "num_cows",
+                    "type": "INT",
+                    "constraints": { "nullable": false }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "game_id,user_id",
+              "baseTableName": "farmer_activity",
+              "constraintName": "FK_FARMER_ACTIVITY_FARMER",
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "game_id,user_id",
+              "referencedTableName": "farmer"
+            }
+          },
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "student_id",
+              "baseTableName": "farmer_activity",
+              "constraintName": "FK_FARMER_ACTIVITY_STUDENT",
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "id",
+              "referencedTableName": "student"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityControllerTests.java
@@ -59,6 +59,7 @@ public class FarmerActivityControllerTests extends ControllerTestCase {
         return Farmer.builder()
                 .user(currentUserService.getUser())
                 .game(testGame)
+                .numOfCows(5)
                 .build();
     }
 
@@ -66,6 +67,8 @@ public class FarmerActivityControllerTests extends ControllerTestCase {
     @Test
     public void pageview_records_activity_when_farmer_exists() throws Exception {
         User currentUser = currentUserService.getUser();
+        // numOfCows=5 (see getTestFarmer): the play-page-view record should
+        // capture this as a numCows snapshot, not leave it at zero.
         Farmer farmer = getTestFarmer();
 
         when(gameRepository.findById(eq(1L))).thenReturn(Optional.of(testGame));
@@ -76,7 +79,7 @@ public class FarmerActivityControllerTests extends ControllerTestCase {
 
         verify(farmerActivityService, times(1)).recordActivityIfStudentMatch(
                 eq(currentUser), eq(testGame), eq(farmer),
-                eq(FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW), eq(0));
+                eq(FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW), eq(5));
     }
 
     @WithMockUser(roles = {"USER"})

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerActivityControllerTests.java
@@ -1,0 +1,159 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.Farmer;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Game;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.repositories.FarmerActivityRepository;
+import edu.ucsb.cs156.happiercows.repositories.FarmerRepository;
+import edu.ucsb.cs156.happiercows.repositories.GameRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
+
+@WebMvcTest(controllers = FarmerActivityController.class)
+public class FarmerActivityControllerTests extends ControllerTestCase {
+
+    @MockBean
+    FarmerActivityRepository farmerActivityRepository;
+
+    @MockBean
+    FarmerRepository farmerRepository;
+
+    @MockBean
+    GameRepository gameRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    FarmerActivityService farmerActivityService;
+
+    Game testGame = Game.builder().id(1L).name("test game").build();
+
+    public Farmer getTestFarmer() {
+        return Farmer.builder()
+                .user(currentUserService.getUser())
+                .game(testGame)
+                .build();
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void pageview_records_activity_when_farmer_exists() throws Exception {
+        User currentUser = currentUserService.getUser();
+        Farmer farmer = getTestFarmer();
+
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.of(testGame));
+        when(farmerRepository.findByGameIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(farmer));
+
+        mockMvc.perform(post("/api/farmeractivity/pageview?gameId=1").with(csrf()))
+                .andExpect(status().isOk());
+
+        verify(farmerActivityService, times(1)).recordActivityIfStudentMatch(
+                eq(currentUser), eq(testGame), eq(farmer),
+                eq(FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW), eq(0));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void pageview_does_not_record_activity_when_farmer_does_not_exist() throws Exception {
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.of(testGame));
+        when(farmerRepository.findByGameIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/farmeractivity/pageview?gameId=1").with(csrf()))
+                .andExpect(status().isOk());
+
+        verify(farmerActivityService, never()).recordActivityIfStudentMatch(
+                any(), any(), any(), anyInt(), anyInt());
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void pageview_returns_404_when_game_does_not_exist() throws Exception {
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(post("/api/farmeractivity/pageview?gameId=1").with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+
+        String expectedString = "{\"message\":\"Game with id 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+
+        verify(farmerActivityService, never()).recordActivityIfStudentMatch(
+                any(), any(), any(), anyInt(), anyInt());
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void admin_can_get_activity_for_a_farmer() throws Exception {
+        Farmer farmer = getTestFarmer();
+        FarmerActivity a1 = FarmerActivity.builder()
+                .id(1L).farmer(farmer).studentId(42L)
+                .timestamp(LocalDateTime.parse("2024-01-15T10:15:30"))
+                .activityType(FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW).numCows(0).build();
+        FarmerActivity a2 = FarmerActivity.builder()
+                .id(2L).farmer(farmer).studentId(42L)
+                .timestamp(LocalDateTime.parse("2024-01-15T10:20:00"))
+                .activityType(FarmerActivity.ACTIVITY_TYPE_BUY).numCows(3).build();
+        List<FarmerActivity> expected = List.of(a2, a1);
+
+        when(farmerRepository.findByGameIdAndUserId(eq(1L), eq(2L))).thenReturn(Optional.of(farmer));
+        when(farmerActivityRepository.findByFarmerOrderByTimestampDesc(farmer)).thenReturn(expected);
+
+        MvcResult response = mockMvc.perform(get("/api/farmeractivity/all?userId=2&gameId=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(farmerActivityRepository, times(1)).findByFarmerOrderByTimestampDesc(farmer);
+
+        String expectedJson = mapper.writeValueAsString(expected);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void admin_get_activity_for_nonexistent_farmer_returns_404() throws Exception {
+        when(farmerRepository.findByGameIdAndUserId(eq(1L), eq(2L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/farmeractivity/all?userId=2&gameId=1"))
+                .andExpect(status().is(404)).andReturn();
+
+        String expectedString = "{\"message\":\"Farmer with gameId 1 and userId 2 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void non_admin_cannot_get_activity_for_a_farmer() throws Exception {
+        mockMvc.perform(get("/api/farmeractivity/all?userId=2&gameId=1"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerControllerTests.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.happiercows.repositories.FarmerRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
 import edu.ucsb.cs156.happiercows.entities.Student;
+import edu.ucsb.cs156.happiercows.models.FarmerWithStudentStatus;
 import edu.ucsb.cs156.happiercows.services.CourseAccessService;
 import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
 import org.junit.jupiter.api.Test;
@@ -571,17 +572,32 @@ public class FarmerControllerTests extends ControllerTestCase {
     @WithMockUser(roles = {"USER"})
     @Test
     public void test_getAllFarmerById_exists() throws Exception {
-        List<Farmer> expectedFarmer = new ArrayList<>();
         Farmer testexpectedFarmer = getTestFarmer();
+        List<Farmer> expectedFarmer = new ArrayList<>();
         expectedFarmer.add(testexpectedFarmer);
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.of(testGame));
         when(farmerRepository.findByGameId(eq(1L))).thenReturn(expectedFarmer);
+        when(courseAccessService.findMatchingStudentForCourseLinkedGame(
+                testexpectedFarmer.getUser(), testGame)).thenReturn(Optional.empty());
 
         MvcResult response = mockMvc.perform(get("/api/farmer/game/all?gameId=1"))
                 .andExpect(status().isOk()).andReturn();
 
         verify(farmerRepository, times(1)).findByGameId(eq(1L));
 
-        String expectedJson = mapper.writeValueAsString(expectedFarmer);
+        FarmerWithStudentStatus expected = FarmerWithStudentStatus.builder()
+                .userId(testexpectedFarmer.getUserId())
+                .gameId(testexpectedFarmer.getGameId())
+                .username(testexpectedFarmer.getUsername())
+                .totalWealth(testexpectedFarmer.getTotalWealth())
+                .numOfCows(testexpectedFarmer.getNumOfCows())
+                .cowHealth(testexpectedFarmer.getCowHealth())
+                .cowsBought(testexpectedFarmer.getCowsBought())
+                .cowsSold(testexpectedFarmer.getCowsSold())
+                .cowDeaths(testexpectedFarmer.getCowDeaths())
+                .student(false)
+                .build();
+        String expectedJson = mapper.writeValueAsString(List.of(expected));
         String responseString = response.getResponse().getContentAsString();
 
         assertEquals(expectedJson, responseString);
@@ -590,20 +606,52 @@ public class FarmerControllerTests extends ControllerTestCase {
     @WithMockUser(roles = {"ADMIN"})
     @Test
     public void test_Admin_getAllFarmerById_exists() throws Exception {
-        List<Farmer> expectedFarmer = new ArrayList<>();
         Farmer testexpectedFarmer = getTestFarmer();
+        List<Farmer> expectedFarmer = new ArrayList<>();
         expectedFarmer.add(testexpectedFarmer);
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.of(testGame));
         when(farmerRepository.findByGameId(eq(1L))).thenReturn(expectedFarmer);
+        when(courseAccessService.findMatchingStudentForCourseLinkedGame(
+                testexpectedFarmer.getUser(), testGame)).thenReturn(Optional.of(
+                        Student.builder().id(42L).build()));
 
         MvcResult response = mockMvc.perform(get("/api/farmer/game/all?gameId=1").with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         verify(farmerRepository, times(1)).findByGameId(eq(1L));
 
-        String expectedJson = mapper.writeValueAsString(expectedFarmer);
+        FarmerWithStudentStatus expected = FarmerWithStudentStatus.builder()
+                .userId(testexpectedFarmer.getUserId())
+                .gameId(testexpectedFarmer.getGameId())
+                .username(testexpectedFarmer.getUsername())
+                .totalWealth(testexpectedFarmer.getTotalWealth())
+                .numOfCows(testexpectedFarmer.getNumOfCows())
+                .cowHealth(testexpectedFarmer.getCowHealth())
+                .cowsBought(testexpectedFarmer.getCowsBought())
+                .cowsSold(testexpectedFarmer.getCowsSold())
+                .cowDeaths(testexpectedFarmer.getCowDeaths())
+                .student(true)
+                .build();
+        String expectedJson = mapper.writeValueAsString(List.of(expected));
         String responseString = response.getResponse().getContentAsString();
 
         assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_getAllFarmerById_game_does_not_exist() throws Exception {
+        when(gameRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/farmer/game/all?gameId=1"))
+                .andExpect(status().is(404)).andReturn();
+
+        verify(farmerRepository, times(0)).findByGameId(anyLong());
+
+        String expectedString = "{\"message\":\"Game with id 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
     }
 
     @WithMockUser(roles = {"USER"})

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/FarmerControllerTests.java
@@ -7,7 +7,10 @@ import edu.ucsb.cs156.happiercows.entities.Farmer;
 import edu.ucsb.cs156.happiercows.repositories.GameRepository;
 import edu.ucsb.cs156.happiercows.repositories.FarmerRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Student;
 import edu.ucsb.cs156.happiercows.services.CourseAccessService;
+import edu.ucsb.cs156.happiercows.services.FarmerActivityService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -42,6 +45,9 @@ public class FarmerControllerTests extends ControllerTestCase {
 
     @MockBean
     CourseAccessService courseAccessService;
+
+    @MockBean
+    FarmerActivityService farmerActivityService;
 
     Game testGame = Game
             .builder()
@@ -144,6 +150,8 @@ public class FarmerControllerTests extends ControllerTestCase {
 
         // arrange
 
+        User currentUser = currentUserService.getUser();
+
         Farmer origFarmer = getTestFarmer();
         origFarmer.setCowsBought(1);
 
@@ -165,6 +173,9 @@ public class FarmerControllerTests extends ControllerTestCase {
         // assert
         verify(farmerRepository, times(1)).findByGameIdAndUserId(eq(1L), eq(1L));
         verify(farmerRepository, times(1)).save(updateFarmer);
+        verify(farmerActivityService, times(1)).recordActivityIfStudentMatch(
+                eq(currentUser), eq(testGame), eq(updateFarmer),
+                eq(FarmerActivity.ACTIVITY_TYPE_BUY), eq(2));
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedReturn, responseString);
     }
@@ -271,6 +282,8 @@ public class FarmerControllerTests extends ControllerTestCase {
 
         // arrange
 
+        User currentUser = currentUserService.getUser();
+
         Farmer origFarmer = getTestFarmer();
         origFarmer.setCowsSold(1);
         origFarmer.setCowHealth(50);
@@ -295,6 +308,9 @@ public class FarmerControllerTests extends ControllerTestCase {
         // assert
         verify(farmerRepository, times(1)).findByGameIdAndUserId(eq(1L), eq(1L));
         verify(farmerRepository, times(1)).save(updatedFarmer);
+        verify(farmerActivityService, times(1)).recordActivityIfStudentMatch(
+                eq(currentUser), eq(testGame), eq(updatedFarmer),
+                eq(FarmerActivity.ACTIVITY_TYPE_SELL), eq(2));
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedReturn, responseString);
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/CourseAccessServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/CourseAccessServiceTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -217,5 +218,66 @@ public class CourseAccessServiceTests {
         List<Long> courseIds = courseAccessService.getCourseIdsForUser(user);
 
         assertEquals(0, courseIds.size());
+    }
+
+    @Test
+    public void findMatchingStudentForCourseLinkedGame_returns_empty_when_game_has_no_course() {
+        User user = User.builder().email("student@ucsb.edu").admin(false).build();
+        Game game = Game.builder().id(1L).courseId(null).build();
+
+        assertEquals(
+                Optional.empty(),
+                courseAccessService.findMatchingStudentForCourseLinkedGame(user, game));
+    }
+
+    @Test
+    public void findMatchingStudentForCourseLinkedGame_returns_matching_student() {
+        User user = User.builder().email("student@ucsb.edu").admin(false).build();
+        Game game = Game.builder().id(1L).courseId(5L).build();
+
+        Student student = Student.builder().id(42L).email("student@ucsb.edu").courseId(5L).build();
+        List<Student> students = new ArrayList<>();
+        students.add(student);
+
+        when(studentRepository.findByCourseId(5L)).thenReturn(students);
+
+        assertEquals(
+                Optional.of(student),
+                courseAccessService.findMatchingStudentForCourseLinkedGame(user, game));
+    }
+
+    @Test
+    public void findMatchingStudentForCourseLinkedGame_matches_umail_domain_canonically() {
+        // See issue #278: a roster row with the @umail.ucsb.edu form must
+        // still match a student logging in with the canonical @ucsb.edu form.
+        User user = User.builder().email("student@ucsb.edu").admin(false).build();
+        Game game = Game.builder().id(1L).courseId(5L).build();
+
+        Student student =
+                Student.builder().id(42L).email("student@umail.ucsb.edu").courseId(5L).build();
+        List<Student> students = new ArrayList<>();
+        students.add(student);
+
+        when(studentRepository.findByCourseId(5L)).thenReturn(students);
+
+        assertEquals(
+                Optional.of(student),
+                courseAccessService.findMatchingStudentForCourseLinkedGame(user, game));
+    }
+
+    @Test
+    public void findMatchingStudentForCourseLinkedGame_returns_empty_when_no_student_matches() {
+        User user = User.builder().email("outsider@ucsb.edu").admin(false).build();
+        Game game = Game.builder().id(1L).courseId(5L).build();
+
+        Student student = Student.builder().id(42L).email("someone-else@ucsb.edu").courseId(5L).build();
+        List<Student> students = new ArrayList<>();
+        students.add(student);
+
+        when(studentRepository.findByCourseId(5L)).thenReturn(students);
+
+        assertEquals(
+                Optional.empty(),
+                courseAccessService.findMatchingStudentForCourseLinkedGame(user, game));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/FarmerActivityServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/FarmerActivityServiceTests.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.entities.Farmer;
+import edu.ucsb.cs156.happiercows.entities.FarmerActivity;
+import edu.ucsb.cs156.happiercows.entities.Game;
+import edu.ucsb.cs156.happiercows.entities.Student;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.repositories.FarmerActivityRepository;
+
+@ExtendWith(SpringExtension.class)
+@Import(FarmerActivityService.class)
+@ContextConfiguration
+public class FarmerActivityServiceTests {
+
+    @MockBean
+    CourseAccessService courseAccessService;
+
+    @MockBean
+    FarmerActivityRepository farmerActivityRepository;
+
+    @Autowired
+    FarmerActivityService farmerActivityService;
+
+    User user = User.builder().id(1L).email("student@ucsb.edu").build();
+    Game game = Game.builder().id(2L).courseId(5L).build();
+    Farmer farmer = Farmer.builder().user(user).game(game).build();
+    Student student = Student.builder().id(42L).email("student@ucsb.edu").courseId(5L).build();
+
+    @Test
+    public void records_activity_when_a_matching_student_is_found() {
+        when(courseAccessService.findMatchingStudentForCourseLinkedGame(user, game))
+                .thenReturn(Optional.of(student));
+
+        farmerActivityService.recordActivityIfStudentMatch(
+                user, game, farmer, FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW, 0);
+
+        FarmerActivity expected = FarmerActivity.builder()
+                .farmer(farmer)
+                .studentId(42L)
+                .activityType(FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW)
+                .numCows(0)
+                .build();
+
+        ArgumentCaptor<FarmerActivity> captor = ArgumentCaptor.forClass(FarmerActivity.class);
+        verify(farmerActivityRepository).save(captor.capture());
+        FarmerActivity saved = captor.getValue();
+
+        assertEquals(expected.getFarmer(), saved.getFarmer());
+        assertEquals(expected.getStudentId(), saved.getStudentId());
+        assertEquals(expected.getActivityType(), saved.getActivityType());
+        assertEquals(expected.getNumCows(), saved.getNumCows());
+    }
+
+    @Test
+    public void records_buy_activity_with_numCows() {
+        when(courseAccessService.findMatchingStudentForCourseLinkedGame(user, game))
+                .thenReturn(Optional.of(student));
+
+        farmerActivityService.recordActivityIfStudentMatch(
+                user, game, farmer, FarmerActivity.ACTIVITY_TYPE_BUY, 3);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(FarmerActivity.class);
+        verify(farmerActivityRepository).save(captor.capture());
+        FarmerActivity saved = captor.getValue();
+
+        assertEquals(FarmerActivity.ACTIVITY_TYPE_BUY, saved.getActivityType());
+        assertEquals(3, saved.getNumCows());
+    }
+
+    @Test
+    public void does_not_record_activity_when_no_matching_student() {
+        when(courseAccessService.findMatchingStudentForCourseLinkedGame(user, game))
+                .thenReturn(Optional.empty());
+
+        farmerActivityService.recordActivityIfStudentMatch(
+                user, game, farmer, FarmerActivity.ACTIVITY_TYPE_PLAY_PAGE_VIEW, 0);
+
+        verify(farmerActivityRepository, never()).save(any());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/FarmerActivityServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/FarmerActivityServiceTests.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -66,6 +69,16 @@ public class FarmerActivityServiceTests {
         assertEquals(expected.getStudentId(), saved.getStudentId());
         assertEquals(expected.getActivityType(), saved.getActivityType());
         assertEquals(expected.getNumCows(), saved.getNumCows());
+
+        // The timestamp must be computed in Pacific time, not whatever the
+        // JVM's own default timezone happens to be (commonly UTC on a
+        // deployed server) - see issue #291.
+        LocalDateTime expectedPacificNow =
+                LocalDateTime.now(ZoneId.of("America/Los_Angeles"));
+        assertEquals(
+                true,
+                Duration.between(expectedPacificNow, saved.getTimestamp()).abs()
+                        .compareTo(Duration.ofSeconds(10)) < 0);
     }
 
     @Test


### PR DESCRIPTION
Closes #291.

## Summary
Adds a `farmer_activity` table tracking three kinds of events for course-linked games: play-page views, buying cows, and selling cows. A row is only recorded when a Game is linked to a Course and the current user's email matches a student on that course's roster (reusing the canonical-email-matching logic already used for course access checks); otherwise the write is silently skipped, not an error.

## Backend
- `FarmerActivity` entity/migration - mirrors `Profit`'s pattern of a `@ManyToOne` over `Farmer`'s composite `(game_id, user_id)` key (Farmer has no single-column PK to reference); `studentId` is a plain FK column since `Student` has a simple `id`.
- `FarmerActivityService.recordActivityIfStudentMatch`, shared by the new `POST /api/farmeractivity/pageview` endpoint and by `FarmerController`'s existing buy/sell endpoints, so the decision logic (and the `Farmer` lookup buy/sell already had in hand) isn't duplicated.
- `GET /api/farmeractivity/all` (admin only, explicit `userId`+`gameId`) returns a farmer's activity history in reverse chronological order.
- `CourseAccessService.findMatchingStudentForCourseLinkedGame` centralizes the "does this user's email match a student on this course" check, following this service's existing canonical-email-matching pattern.
- Activity timestamps are explicitly stamped in `America/Los_Angeles` time (`FarmerActivityService`), not the JVM's default zone (commonly UTC on a deployed server) - `FarmerActivity.timestamp` is a `LocalDateTime` with no zone of its own, matching the same convention already used for announcements/CSV exports elsewhere in this app.
- `GET /api/farmer/game/all` now returns a `FarmerWithStudentStatus` DTO (the previous `Farmer` fields plus a computed `student` boolean) instead of raw `Farmer` entities, so the frontend can tell which leaderboard rows correspond to an actual roster student.

## Frontend
- `PlayPage` records a page-view on mount/navigation via a `useEffect` keyed on `gameId` - **not** `AdminViewPlayPage`, since an admin emulating a farmer's view must not count as a visit (that page is intentionally untouched, per the issue).
- New `AdminFarmerActivityPage` + `FarmerActivityTable` (client-side paged, page sizes 10/50/100, reusing the `PageSizeSelector` component from #290) at `/admin/farmeractivity/:gameId/user/:userId`. Its Timestamp column formats the naive Pacific-time string from its own digits rather than through `new Date(...)`, which would otherwise silently reinterpret it using the *viewing browser's* timezone.
- `LeaderboardTable` gets an admin-only "Activity" column (positioned right after the farmer's name) linking to that page, gated on `isAdminView` (true only for an admin *not* viewing in "Student View") **and** `isCourseLinkedGame` (the column is hidden entirely for games with no course, since activity is never tracked for them). Within that column, a non-student farmer's row shows "Not a student" instead of a button, since no activity is tracked for them either.

## Test plan
- [x] `mvn verify` (JaCoCo 100% coverage)
- [x] Pitest 100% mutation score on all new/changed backend classes
- [x] Frontend `vitest` (785 tests, 100% coverage)
- [x] Stryker 100% mutation score on all changed/new frontend files
- [ ] Manually verify on QA: play a game linked to a course as a student → activity rows accumulate, timestamps show correct Pacific time; view the leaderboard as admin → "Activity" button appears (second column) for student farmers, "Not a student" for others, and the whole column is absent for non-course games; toggle "View as Student" → button disappears; view a game as an admin via "emulate" → no activity row recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)