### PR TITLE
Add page size selector to Participation Grade preview table (#320)

### DIFF
--- a/frontend/src/main/components/Courses/ParticipationGradeTabComponent.jsx
+++ b/frontend/src/main/components/Courses/ParticipationGradeTabComponent.jsx
@@ -12,7 +12,13 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
 import OurTable from "main/components/OurTable";
+import PageSizeSelector from "main/components/Utils/PageSizeSelector";
 import { useBackendMutation } from "main/utils/useBackend";
+import usePageSize from "main/utils/usePageSize";
+
+const PAGE_SIZE_OPTIONS = [20, 50, 100, 200, 500];
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_STORAGE_KEY = "participation-grade-page-size";
 
 const DEFAULT_VALUES = {
   startDate: "",
@@ -71,6 +77,12 @@ export default function ParticipationGradeTabComponent({
 
   const [grades, setGrades] = useState(null);
   const [downloadParams, setDownloadParams] = useState(null);
+
+  const [pageSize, handlePageSizeChange] = usePageSize({
+    storageKey: PAGE_SIZE_STORAGE_KEY,
+    options: PAGE_SIZE_OPTIONS,
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+  });
 
   const criterion1Weight = watch("criterion1Weight");
   const criterion2Weight = watch("criterion2Weight");
@@ -370,7 +382,20 @@ export default function ParticipationGradeTabComponent({
       </Form>
 
       {grades && (
-        <OurTable data={grades} columns={columns} testid={`${testid}-table`} />
+        <>
+          <PageSizeSelector
+            value={pageSize}
+            onChange={handlePageSizeChange}
+            options={PAGE_SIZE_OPTIONS}
+            testid={`${testid}-table-page-size-selector`}
+          />
+          <OurTable
+            data={grades}
+            columns={columns}
+            testid={`${testid}-table`}
+            pageSize={pageSize}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/src/tests/components/Courses/ParticipationGradeTabComponent.test.jsx
+++ b/frontend/src/tests/components/Courses/ParticipationGradeTabComponent.test.jsx
@@ -23,6 +23,7 @@ describe("ParticipationGradeTabComponent tests", () => {
     axiosMock.reset();
     axiosMock.resetHistory();
     mockToast.mockClear();
+    localStorage.clear();
   });
 
   const renderComponent = () =>
@@ -46,6 +47,8 @@ describe("ParticipationGradeTabComponent tests", () => {
   test("renders the form with the expected default weights", () => {
     renderComponent();
 
+    expect(screen.getByTestId(`${testid}-startDate`)).toHaveValue("");
+    expect(screen.getByTestId(`${testid}-endDate`)).toHaveValue("");
     expect(screen.getByTestId(`${testid}-criterion1Weight`)).toHaveValue(40);
     expect(screen.getByTestId(`${testid}-criterion2Weight`)).toHaveValue(40);
     expect(screen.getByTestId(`${testid}-criterion2MinDays`)).toHaveValue(5);
@@ -104,6 +107,9 @@ describe("ParticipationGradeTabComponent tests", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId(`${testid}-download-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testid}-table-page-size-selector`),
     ).not.toBeInTheDocument();
   });
 
@@ -655,6 +661,111 @@ describe("ParticipationGradeTabComponent tests", () => {
     ).toHaveTextContent("No");
 
     expect(mockToast).toHaveBeenCalledWith("Computed grades for 2 student(s).");
+  });
+
+  const manyGrades = Array.from({ length: 25 }, (_, i) => ({
+    studentId: i + 1,
+    perm: `100000${i}`,
+    lastName: `Last${i + 1}`,
+    firstMiddleName: `First${i + 1}`,
+    interactedAtLeastOnce: true,
+    daysInteracted: 1,
+    ownedAndCheckedInOnACow: true,
+    criterion1PointsEarned: 40,
+    criterion2PointsEarned: 40,
+    criterion3PointsEarned: 20,
+    totalPointsEarned: 100,
+  }));
+
+  test("renders a Page Size selector defaulting to 20 after a preview", async () => {
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    const selector = await screen.findByTestId(
+      `${testid}-table-page-size-selector`,
+    );
+    expect(selector).toHaveValue("20");
+  });
+
+  test("with more grades than the page size, pagination is shown and only a page's worth of rows render", async () => {
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    expect(
+      await screen.findByTestId(`${testid}-table-current-page-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testid}-table-cell-row-0-col-perm`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testid}-table-cell-row-20-col-perm`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("selecting a page size larger than the number of grades shows all rows and hides pagination", async () => {
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    const selector = await screen.findByTestId(
+      `${testid}-table-page-size-selector`,
+    );
+    fireEvent.change(selector, { target: { value: "50" } });
+
+    expect(
+      screen.queryByTestId(`${testid}-table-current-page-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testid}-table-cell-row-24-col-perm`),
+    ).toBeInTheDocument();
+  });
+
+  test("selecting a page size stores it in localStorage under 'participation-grade-page-size'", async () => {
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    const selector = await screen.findByTestId(
+      `${testid}-table-page-size-selector`,
+    );
+    fireEvent.change(selector, { target: { value: "100" } });
+
+    await waitFor(() => {
+      expect(localStorage.getItem("participation-grade-page-size")).toBe("100");
+    });
+  });
+
+  test("uses the page size stored in localStorage when it is a valid option", async () => {
+    localStorage.setItem("participation-grade-page-size", "50");
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    const selector = await screen.findByTestId(
+      `${testid}-table-page-size-selector`,
+    );
+    expect(selector).toHaveValue("50");
+  });
+
+  test("falls back to 20 and updates localStorage when the stored page size is not a valid option", async () => {
+    localStorage.setItem("participation-grade-page-size", "37");
+    axiosMock.onGet("/api/participationgrade/compute").reply(200, manyGrades);
+    renderComponent();
+    fillDates("2026-01-01", "2026-01-10");
+    fireEvent.click(screen.getByTestId(`${testid}-preview-button`));
+
+    const selector = await screen.findByTestId(
+      `${testid}-table-page-size-selector`,
+    );
+    expect(selector).toHaveValue("20");
+    expect(localStorage.getItem("participation-grade-page-size")).toBe("20");
   });
 
   test("shows a Download CSV button with a matching query string only after a successful preview", async () => {


### PR DESCRIPTION
## Summary
- Adds a page size selector to the Participation Grade preview table (the "Participation Grade" tab of `/admin/courses/:id`), which previously had no way to change the page size and fell back to `OurTable`'s default of 10 rows.
- Reuses the existing `usePageSize` hook and shared `PageSizeSelector` component, following the same pattern already used by the Students, Reports, Report Lines, and Leaderboard tables.
- Same page size options as those tables: `[20, 50, 100, 200, 500]`, defaulting to 20, cached to `localStorage` under `participation-grade-page-size`.

Fixes #320

## Test plan
- [x] Frontend: 100% line/branch/function/statement coverage (Vitest, 888/888 tests passing)
- [x] Frontend: 100% Stryker mutation score on `ParticipationGradeTabComponent.jsx`, confirmed on two consecutive runs
- [x] ESLint and Prettier clean

Manual verification:
1. Compute a grade preview for a course with 25+ students so pagination appears.
2. Change the page size dropdown and confirm the table re-renders with the new number of rows per page, and that `localStorage`'s `participation-grade-page-size` key updates to match.
3. Reload the page, compute another preview, and confirm the previously-selected page size is remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)