### PR TITLE
Add page size selector to Admin Users table (#322)

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.jsx
+++ b/frontend/src/main/components/Users/UsersTable.jsx
@@ -1,8 +1,14 @@
 import React, { useState } from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import PageSizeSelector from "main/components/Utils/PageSizeSelector";
 import { formatTime } from "main/utils/dateUtils";
 import { useRestoreUser, useSuspendUser } from "main/utils/users";
+import usePageSize from "main/utils/usePageSize";
 import { Button, Modal } from "react-bootstrap";
+
+const PAGE_SIZE_OPTIONS = [20, 50, 100, 200, 500];
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_STORAGE_KEY = "users-page-size";
 
 export default function UsersTable({ users }) {
   const { mutate: suspendUser } = useSuspendUser();
@@ -10,6 +16,12 @@ export default function UsersTable({ users }) {
   const [showSuspendModal, setShowSuspendModal] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const [selectedCell, setSelectedCell] = useState(null);
+
+  const [pageSize, handlePageSizeChange] = usePageSize({
+    storageKey: PAGE_SIZE_STORAGE_KEY,
+    options: PAGE_SIZE_OPTIONS,
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+  });
 
   const suspendCallback = async (cell) => {
     setSelectedCell(cell);
@@ -107,7 +119,18 @@ export default function UsersTable({ users }) {
 
   return (
     <>
-      <OurTable data={users} columns={columns} testid={"UsersTable"} />
+      <PageSizeSelector
+        value={pageSize}
+        onChange={handlePageSizeChange}
+        options={PAGE_SIZE_OPTIONS}
+        testid={"UsersTable-page-size-selector"}
+      />
+      <OurTable
+        data={users}
+        columns={columns}
+        testid={"UsersTable"}
+        pageSize={pageSize}
+      />
       {suspendModal}
       {restoreModal}
     </>

--- a/frontend/src/tests/components/Users/UsersTable.test.jsx
+++ b/frontend/src/tests/components/Users/UsersTable.test.jsx
@@ -12,6 +12,10 @@ vi.mock("main/utils/users", async () => ({
 }));
 
 describe("UserTable tests", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   test("renders without crashing for empty table", () => {
     render(<UsersTable users={[]} />);
   });
@@ -119,6 +123,78 @@ describe("UserTable tests", () => {
     await waitFor(() => {
       expect(getVisibleIdOrder()).toEqual(["2", "1", "3"]);
     });
+  });
+
+  const manyUsers = Array.from({ length: 25 }, (_, i) => ({
+    ...usersFixtures.threeUsers[0],
+    id: i + 1,
+    email: `user${i + 1}@ucsb.edu`,
+  }));
+
+  test("renders a Page Size selector defaulting to 20", () => {
+    render(<UsersTable users={manyUsers} />);
+
+    const selector = screen.getByTestId("UsersTable-page-size-selector");
+    expect(selector).toBeInTheDocument();
+    expect(selector).toHaveValue("20");
+  });
+
+  test("with more users than the page size, pagination is shown and only a page's worth of rows render", () => {
+    render(<UsersTable users={manyUsers} />);
+
+    expect(
+      screen.getByTestId("UsersTable-current-page-button"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("UsersTable-cell-row-0-col-id"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("UsersTable-cell-row-20-col-id"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("selecting a page size larger than the number of users shows all rows and hides pagination", () => {
+    render(<UsersTable users={manyUsers} />);
+
+    const selector = screen.getByTestId("UsersTable-page-size-selector");
+    fireEvent.change(selector, { target: { value: "50" } });
+
+    expect(
+      screen.queryByTestId("UsersTable-current-page-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("UsersTable-cell-row-24-col-id"),
+    ).toBeInTheDocument();
+  });
+
+  test("selecting a page size stores it in localStorage under 'users-page-size'", async () => {
+    render(<UsersTable users={manyUsers} />);
+
+    const selector = screen.getByTestId("UsersTable-page-size-selector");
+    fireEvent.change(selector, { target: { value: "50" } });
+
+    await waitFor(() => {
+      expect(localStorage.getItem("users-page-size")).toBe("50");
+    });
+  });
+
+  test("uses the page size stored in localStorage when it is a valid option", () => {
+    localStorage.setItem("users-page-size", "50");
+
+    render(<UsersTable users={manyUsers} />);
+
+    const selector = screen.getByTestId("UsersTable-page-size-selector");
+    expect(selector).toHaveValue("50");
+  });
+
+  test("falls back to 20 and updates localStorage when the stored value is not a valid option", () => {
+    localStorage.setItem("users-page-size", "37");
+
+    render(<UsersTable users={manyUsers} />);
+
+    const selector = screen.getByTestId("UsersTable-page-size-selector");
+    expect(selector).toHaveValue("20");
+    expect(localStorage.getItem("users-page-size")).toBe("20");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a page size selector above the Users table on `/admin/users`, which previously had no way to change the page size.
- Reuses the existing `usePageSize` hook and shared `PageSizeSelector` component, following the same pattern already used by the Students, Reports, Report Lines, and Leaderboard tables.
- Same page size options as those tables: `[20, 50, 100, 200, 500]`, defaulting to 20, cached to `localStorage` under `users-page-size`.

Fixes #322

## Test Plan
1. Log in as a user with the `ROLE_ADMIN` role.
2. Navigate to `/admin/users`.
3. Confirm a "Page Size" selector appears above the Users table, defaulting to 20.
4. Change the selector to a different value (e.g. 50) and confirm the table re-renders with that many rows per page (or all rows, if fewer exist).
5. Open the browser's dev tools and confirm `localStorage`'s `users-page-size` key is set to the newly-selected value.
6. Reload the page and confirm the previously-selected page size is remembered.

## Quality Checks
- [x] Frontend: 100% line/branch/function/statement coverage (Vitest, 888/888 tests passing)
- [x] Frontend: 100% Stryker mutation score on `UsersTable.jsx`, confirmed on two consecutive runs (0 survived, 0 timeouts both times)
- [x] ESLint and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)